### PR TITLE
add api to modify server outside of New method

### DIFF
--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -12,7 +12,7 @@ import (
 	certificate "github.com/qinqon/kube-admission-webhook/pkg/webhook/server/certificate"
 )
 
-type server struct {
+type Server struct {
 	mgr           manager.Manager
 	webhookName   string
 	webhookType   certificate.WebhookType
@@ -24,8 +24,8 @@ type ServerModifier func(w *webhook.Server)
 
 // Add creates a new Conditions Mutating Webhook and adds it to the Manager. The Manager will set fields on the Webhook
 // and Start it when the Manager is Started.
-func New(mgr manager.Manager, webhookName string, webhookType certificate.WebhookType, serverOpts ...ServerModifier) *server {
-	s := &server{
+func New(mgr manager.Manager, webhookName string, webhookType certificate.WebhookType, serverOpts ...ServerModifier) *Server {
+	s := &Server{
 		webhookName: webhookName,
 		webhookType: webhookType,
 		webhookServer: &webhook.Server{
@@ -35,9 +35,8 @@ func New(mgr manager.Manager, webhookName string, webhookType certificate.Webhoo
 		mgr: mgr,
 		log: logf.Log.WithName("webhook/server"),
 	}
-	for _, serverOpt := range serverOpts {
-		serverOpt(s.webhookServer)
-	}
+	s.UpdateOpts(serverOpts...)
+
 	return s
 }
 
@@ -59,7 +58,14 @@ func WithCertDir(certDir string) ServerModifier {
 	}
 }
 
-func (s *server) Start(stop <-chan struct{}) error {
+//updates Server parameters using ServerModifier functions. Once the manager is started these parameters cannot be updated
+func (s *Server) UpdateOpts(serverOpts ...ServerModifier) {
+	for _, serverOpt := range serverOpts {
+		serverOpt(s.webhookServer)
+	}
+}
+
+func (s *Server) Start(stop <-chan struct{}) error {
 	s.log.Info("Starting nodenetworkconfigurationpolicy webhook server")
 
 	certManager, err := certificate.NewManager(s.mgr, s.webhookName, s.webhookType, s.webhookServer.CertDir, "tls.crt", "tls.key")
@@ -80,10 +86,10 @@ func (s *server) Start(stop <-chan struct{}) error {
 	return nil
 }
 
-func (s *server) InjectFunc(f inject.Func) error {
+func (s *Server) InjectFunc(f inject.Func) error {
 	return s.webhookServer.InjectFunc(f)
 }
 
-func (s *server) NeedLeaderElection() bool {
+func (s *Server) NeedLeaderElection() bool {
 	return s.webhookServer.NeedLeaderElection()
 }


### PR DESCRIPTION
Currently you can modify server modifiers from New() method. 
It is in some cases required to add a server modifier outside of this method.
This PR exposes ServerUpdate() api method, to do just that.

Signed-off-by: Ram Lavi <ralavi@redhat.com>