### PR TITLE
Manage secret's owner correctly

### DIFF
--- a/pkg/webhook/server/certificate/manager_test.go
+++ b/pkg/webhook/server/certificate/manager_test.go
@@ -103,7 +103,14 @@ func TestWaitForDeadlineAndRotate(t *testing.T) {
 		},
 	}
 
-	objs := []runtime.Object{mutatingWebhookConfiguration}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "fooWebhook",
+			Name:      "fooWebhook",
+		},
+	}
+
+	objs := []runtime.Object{mutatingWebhookConfiguration, service}
 
 	client := fake.NewFakeClient(objs...)
 	certsDuration := time.Minute

--- a/pkg/webhook/server/certificate/secret.go
+++ b/pkg/webhook/server/certificate/secret.go
@@ -3,6 +3,8 @@ package certificate
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,33 +14,53 @@ import (
 	"github.com/qinqon/kube-admission-webhook/pkg/webhook/server/certificate/triple"
 )
 
-func tlsSecret(service types.NamespacedName, keyPair *triple.KeyPair) corev1.Secret {
+func updateTLSSecret(secret corev1.Secret, keyPair *triple.KeyPair) *corev1.Secret {
+	secret.Data = map[string][]byte{
+		corev1.TLSCertKey:       triple.EncodeCertPEM(keyPair.Cert),
+		corev1.TLSPrivateKeyKey: triple.EncodePrivateKeyPEM(keyPair.Key),
+	}
+	secret.Type = corev1.SecretTypeTLS
+	return &secret
+}
+
+func (m *Manager) newTLSSecret(serviceKey types.NamespacedName, keyPair *triple.KeyPair) (*corev1.Secret, error) {
+	service := corev1.Service{}
+	err := m.get(serviceKey, &service)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting service %s to set secret owner", serviceKey)
+	}
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      service.Name,
 			Namespace: service.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name:       service.Name,
+					Kind:       service.TypeMeta.Kind,
+					APIVersion: service.TypeMeta.APIVersion,
+					UID:        service.UID},
+			},
 		},
-		Data: map[string][]byte{
-			corev1.TLSCertKey:       triple.EncodeCertPEM(keyPair.Cert),
-			corev1.TLSPrivateKeyKey: triple.EncodePrivateKeyPEM(keyPair.Key),
-		},
-		Type: corev1.SecretTypeTLS,
 	}
-	return secret
+	return updateTLSSecret(secret, keyPair), nil
 }
 
 func (m *Manager) applyTLSSecret(service types.NamespacedName, keyPair *triple.KeyPair) error {
-	tlsSecret := tlsSecret(service, keyPair)
+	secret := corev1.Secret{}
 
-	err := m.get(service, &corev1.Secret{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return m.client.Create(context.TODO(), &tlsSecret)
-		} else {
-			return err
-		}
-	}
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return m.client.Update(context.TODO(), &tlsSecret)
+		err := m.get(service, &secret)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				tlsSecret, err := m.newTLSSecret(service, keyPair)
+				if err != nil {
+					return errors.Wrapf(err, "failed initailizing secret %s", service)
+				}
+				return m.client.Create(context.TODO(), tlsSecret)
+			} else {
+				return err
+			}
+		}
+		return m.client.Update(context.TODO(), updateTLSSecret(secret, keyPair))
 	})
 }


### PR DESCRIPTION
In case secret is new it will set the service as the owner, if it's an update it will
not touch it.

Signed-off-by: Quique Llorente <ellorent@redhat.com>