### PR TITLE
fix index out of range error when trying to access client-config arra…

### DIFF
--- a/pkg/webhook/server/certificate/configuration.go
+++ b/pkg/webhook/server/certificate/configuration.go
@@ -109,5 +109,11 @@ func (m *Manager) CABundle() ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get %s webhook configuration %s", m.webhookType, m.webhookName)
 	}
-	return m.clientConfigList(webhook)[0].CABundle, nil
+
+	clientConfigList := m.clientConfigList(webhook)
+	if clientConfigList == nil || len(clientConfigList) == 0 {
+		return nil, errors.Wrapf(err, "failed to access CABundle clientConfigList is empty in %s webhook configuration %s", m.webhookType, m.webhookName)
+	}
+
+	return clientConfigList[0].CABundle, nil
 }


### PR DESCRIPTION
…y in empty webhook instance

in order to avoid accessing client-config (that holds the caBundle in the mutating/validating webhook configuration instance) in a case where such webhook section does not exist, we added a protection check.

Signed-off-by: Ram Lavi <ralavi@redhat.com>