### PR TITLE
Implement caBundle overlapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ testenv:
 	hack/setup-testenv.sh
 
 test: $(GO) testenv
-	KUBEBUILDER_ASSETS=$(BIN_DIR) $(GO) test $(WHAT) -timeout 2m -ginkgo.v -ginkgo.noColor=true -test.v
+	KUBEBUILDER_ASSETS=$(BIN_DIR) $(GO) test $(WHAT) -timeout 2m -ginkgo.v -ginkgo.noColor=false  -test.v
 
 pod:
 	$(GO) build -o $(BIN_DIR) ./pkg/... ./test/pod

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The library generates RSA keys with 2048 size and certificate for both for CA an
 They share the expiration time so all the CA and service certificates
 are rotated at once just before expiration time.
 
+The CA bundle from webhook configuratin contains not only the last rotated
+CA certificate but also the non expired previous one, that prevents problems
+related to pods watching an old projection of the mounted secret.
+
 ## Webhook service
 It has a one year expiration time harcoded and apart from wrapping the
 controller runtime webhook library it waits for TLS key/cert existence and

--- a/pkg/certificate/cleanup.go
+++ b/pkg/certificate/cleanup.go
@@ -1,0 +1,85 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/qinqon/kube-admission-webhook/pkg/certificate/triple"
+)
+
+// earliestElapsedForCleanup return a subtraction between earliestCleanupDeadline and
+// `now`
+func (m *Manager) earliestElapsedForCleanup() (time.Duration, error) {
+	deadline, err := m.earliestCleanupDeadline()
+	if err != nil {
+		return time.Duration(0), errors.Wrap(err, "failed calculating cleanup deadline")
+	}
+	now := m.now()
+	elapsedForCleanup := deadline.Sub(now)
+	m.log.Info(fmt.Sprintf("earliestElapsedForCleanup {now: %s, deadline: %s, elapsedForCleanup: %s}", now, deadline, elapsedForCleanup))
+	return elapsedForCleanup, nil
+}
+
+// earliestCleanupDeadline get all the certificates at CABundle and return the
+// deadline calculated by earliestCleanupDeadlineForCerts
+func (m *Manager) earliestCleanupDeadline() (time.Time, error) {
+	cas, err := m.getCACertsFromCABundle()
+	if err != nil {
+		return m.now(), errors.Wrap(err, "failed getting CA certificates from CA bundle")
+	}
+
+	return m.earliestCleanupDeadlineForCerts(cas), nil
+}
+
+// earliestCleanupDeadlineForCACerts will inspect CA certificates
+// select the deadline based on certificate that is going to expire
+// sooner so cleanup is triggered then
+func (m *Manager) earliestCleanupDeadlineForCerts(certificates []*x509.Certificate) time.Time {
+
+	var selectedCertificate *x509.Certificate
+
+	for _, certificate := range certificates {
+		if selectedCertificate == nil || certificate.NotAfter.Before(selectedCertificate.NotAfter) {
+			selectedCertificate = certificate
+		}
+	}
+	if selectedCertificate == nil {
+		return m.now()
+	}
+
+	return selectedCertificate.NotAfter
+}
+
+func (m *Manager) cleanUpCABundle() error {
+	logger := m.log.WithName("cleanUpCABundle")
+	logger.Info("Cleaning up expired certificates at CA bundle")
+	_, err := m.updateWebhookCABundleWithFunc(func([]byte) ([]byte, error) {
+		cas, err := m.getCACertsFromCABundle()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed getting ca certs to start cleanup")
+		}
+		cleanedCAs := m.cleanUpExpiredCertificates(cas)
+		pem := triple.EncodeCertsPEM(cleanedCAs)
+		return pem, nil
+	})
+
+	if err != nil {
+		return errors.Wrap(err, "failed updating webhook config after ca certificates cleanup")
+	}
+	return nil
+}
+
+func (m *Manager) cleanUpExpiredCertificates(certificates []*x509.Certificate) []*x509.Certificate {
+	now := m.now()
+	// create a zero-length slice with the same underlying array
+	cleanedUpCertificates := certificates[:0]
+	for _, certificate := range certificates {
+		if certificate.NotAfter.After(now) {
+			cleanedUpCertificates = append(cleanedUpCertificates, certificate)
+		}
+	}
+	return cleanedUpCertificates
+}

--- a/pkg/certificate/cleanup_test.go
+++ b/pkg/certificate/cleanup_test.go
@@ -1,0 +1,301 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CABundle cleanup", func() {
+	var (
+		now time.Time
+	)
+	BeforeEach(func() {
+		now = time.Now()
+	})
+	type certificateExpiration struct {
+		notBefore time.Duration
+		notAfter  time.Duration
+	}
+	expirationsToCertificates := func(expirations []certificateExpiration) []*x509.Certificate {
+		certificates := []*x509.Certificate{}
+		for _, expiration := range expirations {
+			certificates = append(certificates, &x509.Certificate{
+				NotBefore: now.Add(expiration.notBefore),
+				NotAfter:  now.Add(expiration.notAfter),
+			})
+		}
+		return certificates
+	}
+
+	type earliestCleanupDeadlineCase struct {
+		certsExpiration []certificateExpiration
+		expectedElapsed time.Duration
+	}
+	DescribeTable("earliestCleanupDeadline",
+		func(c earliestCleanupDeadlineCase) {
+
+			m := Manager{
+				now: func() time.Time { return now },
+				log: log,
+			}
+
+			certificates := expirationsToCertificates(c.certsExpiration)
+
+			obtainedDeadline := m.earliestCleanupDeadlineForCerts(certificates)
+			obtainedElapsed := obtainedDeadline.Sub(now)
+			Expect(obtainedElapsed).To(Equal(c.expectedElapsed))
+		},
+		Entry("empty certificates, deadline is now", earliestCleanupDeadlineCase{
+			certsExpiration: []certificateExpiration{},
+			expectedElapsed: time.Duration(0),
+		}),
+		Entry("one certificate, deadline is certificate's expiration time", earliestCleanupDeadlineCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  99 * time.Hour,
+				},
+			},
+			expectedElapsed: 99 * time.Hour,
+		}),
+		Entry("first one sooner, deadline taken from it", earliestCleanupDeadlineCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  88 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  99 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  101 * time.Hour,
+				},
+			},
+			expectedElapsed: 88 * time.Hour,
+		}),
+		Entry("second one sooner, deadline taken from it", earliestCleanupDeadlineCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  88 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  77 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  101 * time.Hour,
+				},
+			},
+			expectedElapsed: 77 * time.Hour,
+		}),
+		Entry("third one sooner, deadline taken from it", earliestCleanupDeadlineCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  99 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  77 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  66 * time.Hour,
+				},
+			},
+			expectedElapsed: 66 * time.Hour,
+		}),
+	)
+	type cleanUpExpiredCertificatesCase struct {
+		certsExpiration         []certificateExpiration
+		expectedCertsExpiration []certificateExpiration
+	}
+	DescribeTable("cleanUpExpiredCertificates",
+		func(c cleanUpExpiredCertificatesCase) {
+
+			m := Manager{
+				now: func() time.Time { return now },
+				log: log,
+			}
+
+			certificates := expirationsToCertificates(c.certsExpiration)
+			cleanedUpCertificates := m.cleanUpExpiredCertificates(certificates)
+			expectedCertificates := expirationsToCertificates(c.expectedCertsExpiration)
+			Expect(cleanedUpCertificates).To(Equal(expectedCertificates), "should have proper certificates cleanup")
+
+		},
+		Entry("empty caBundle do noop", cleanUpExpiredCertificatesCase{
+			certsExpiration:         []certificateExpiration{},
+			expectedCertsExpiration: []certificateExpiration{},
+		}),
+		Entry("none expired, should keep them", cleanUpExpiredCertificatesCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  11 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  99 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  101 * time.Hour,
+				},
+			},
+			expectedCertsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  11 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  99 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  101 * time.Hour,
+				},
+			},
+		}),
+
+		Entry("first one expired right now, should remove it", cleanUpExpiredCertificatesCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  0 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  99 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  101 * time.Hour,
+				},
+			},
+			expectedCertsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  99 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  101 * time.Hour,
+				},
+			},
+		}),
+		Entry("first one expired long ago, should remove it", cleanUpExpiredCertificatesCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -99 * time.Hour,
+					notAfter:  -77 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  66 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  33 * time.Hour,
+				},
+			},
+			expectedCertsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  66 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  33 * time.Hour,
+				},
+			},
+		}),
+		Entry("middle one expired right now, should remove it", cleanUpExpiredCertificatesCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  33 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  0 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  101 * time.Hour,
+				},
+			},
+			expectedCertsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  33 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  101 * time.Hour,
+				},
+			},
+		}),
+		Entry("middle one expired long ago, should remove it", cleanUpExpiredCertificatesCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  77 * time.Hour,
+				},
+				{
+					notBefore: -99 * time.Hour,
+					notAfter:  -66 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  33 * time.Hour,
+				},
+			},
+			expectedCertsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  77 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  33 * time.Hour,
+				},
+			},
+		}),
+		Entry("last one expired long ago, should remove it", cleanUpExpiredCertificatesCase{
+			certsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  77 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  80 * time.Hour,
+				},
+				{
+					notBefore: -34 * time.Hour,
+					notAfter:  -33 * time.Hour,
+				},
+			},
+			expectedCertsExpiration: []certificateExpiration{
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  77 * time.Hour,
+				},
+				{
+					notBefore: -1 * time.Hour,
+					notAfter:  80 * time.Hour,
+				},
+			},
+		}),
+	)
+})

--- a/pkg/certificate/triple/pem.go
+++ b/pkg/certificate/triple/pem.go
@@ -71,6 +71,16 @@ func EncodeCertPEM(cert *x509.Certificate) []byte {
 	return pem.EncodeToMemory(&block)
 }
 
+// EncodeCertsPEM returns PEM-endcoded certificates data
+func EncodeCertsPEM(certs []*x509.Certificate) []byte {
+	certsPEM := []byte{}
+	for _, cert := range certs {
+		certPEM := EncodeCertPEM(cert)
+		certsPEM = append(certsPEM, certPEM...)
+	}
+	return certsPEM
+}
+
 // ParsePrivateKeyPEM returns a private key parsed from a PEM block in the supplied data.
 // Recognizes PEM blocks for "EC PRIVATE KEY", "RSA PRIVATE KEY", or "PRIVATE KEY"
 func ParsePrivateKeyPEM(keyData []byte) (interface{}, error) {


### PR DESCRIPTION
Right now caBundle only store the rotated ca and discard the old ca that was previously there, this introduces problems since it takes some time for the secret to be updated into the pod when it's mounted, during this time if caBundle does not conserve the previous CA webhook traffic will fail.

To do that this PR add the rotate CA to ca bundle instead of replace it and implements at caBundle cleanup mechanism based on expiration time.

Signed-off-by: Quique Llorente <ellorent@redhat.com>