### PR TITLE
Skip Reconcile at Secret cascade delete

### DIFF
--- a/test/pod/main.go
+++ b/test/pod/main.go
@@ -75,8 +75,8 @@ func main() {
 
 	// Setup webhooks
 	entryLog.Info("setting up webhook server")
-	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.MutatingWebhook)
-	validatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.ValidatingWebhook)
+	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.MutatingWebhook, certificate.OneYearDuration)
+	validatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.ValidatingWebhook, certificate.OneYearDuration)
 
 	entryLog.Info("registering webhooks to the webhook server")
 	mutatingWebhookServer.UpdateOpts(webhookserver.WithHook("/mutate-v1-pod", &webhook.Admission{Handler: &podAnnotator{Client: mgr.GetClient()}}))


### PR DESCRIPTION
A cascade delete of a Secret means that the Services or owner is gone so secret should
be gone too, if we don't skip Reconcile there the secret could be re-created if Service
is not gone at that time.

Signed-off-by: Quique Llorente <ellorent@redhat.com>