### PR TITLE
Use new knob for the service certificate rotation

### DIFF
--- a/pkg/certificate/certificate_suite_test.go
+++ b/pkg/certificate/certificate_suite_test.go
@@ -70,7 +70,7 @@ var (
 	expectedCASecret = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
-			Name:      expectedMutatingWebhookConfiguration.Name,
+			Name:      expectedMutatingWebhookConfiguration.Name + "-ca",
 		},
 	}
 )

--- a/pkg/certificate/certificate_suite_test.go
+++ b/pkg/certificate/certificate_suite_test.go
@@ -69,7 +69,7 @@ var (
 
 	expectedCASecret = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
+			Namespace: expectedNamespace.Name,
 			Name:      expectedMutatingWebhookConfiguration.Name + "-ca",
 		},
 	}

--- a/pkg/certificate/certificate_suite_test.go
+++ b/pkg/certificate/certificate_suite_test.go
@@ -66,6 +66,13 @@ var (
 	expectedSecret = corev1.Secret{
 		ObjectMeta: expectedService.ObjectMeta,
 	}
+
+	expectedCASecret = corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      expectedMutatingWebhookConfiguration.Name,
+		},
+	}
 )
 
 func createResources() {

--- a/pkg/certificate/configuration.go
+++ b/pkg/certificate/configuration.go
@@ -147,7 +147,7 @@ func (m *Manager) CABundle() ([]byte, error) {
 
 // getServicesFromConfiguration it retrieves all the references services at
 // webhook configuration clientConfig and in case there is no service ref
-// it will refernece fake one with webhook name, default namespaces and
+// it will refernece fake one with webhook name, mgr namespace and
 // passing the url hostname at map value
 func (m *Manager) getServicesFromConfiguration(configuration runtime.Object) (map[types.NamespacedName][]string, error) {
 
@@ -166,7 +166,7 @@ func (m *Manager) getServicesFromConfiguration(configuration runtime.Object) (ma
 		} else if clientConfig.URL != nil {
 			logger.Info("Composing service name and namespace from URL", "URL", clientConfig.URL)
 			service.Name = m.webhookName
-			service.Namespace = "default"
+			service.Namespace = m.namespace
 			u, err := url.Parse(*clientConfig.URL)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed parsing webhook URL %s", *clientConfig.URL)

--- a/pkg/certificate/configuration.go
+++ b/pkg/certificate/configuration.go
@@ -80,9 +80,9 @@ func (m *Manager) readyWebhookConfiguration() (runtime.Object, error) {
 	return webhook, err
 }
 
-func (m *Manager) addCertificateToCABundle(caCert *x509.Certificate) (runtime.Object, error) {
+func (m *Manager) addCertificateToCABundle(caCert *x509.Certificate) error {
 	m.log.Info("Reset CA bundle with one cert for webhook")
-	webhook, err := m.updateWebhookCABundleWithFunc(func(currentCABundle []byte) ([]byte, error) {
+	_, err := m.updateWebhookCABundleWithFunc(func(currentCABundle []byte) ([]byte, error) {
 		cas := []*x509.Certificate{}
 		if len(currentCABundle) > 0 {
 			var err error
@@ -95,9 +95,9 @@ func (m *Manager) addCertificateToCABundle(caCert *x509.Certificate) (runtime.Ob
 		return triple.EncodeCertsPEM(cas), nil
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to update webhook CABundle")
+		return errors.Wrap(err, "failed to update webhook CABundle")
 	}
-	return webhook, nil
+	return nil
 }
 
 func (m *Manager) updateWebhookCABundleWithFunc(updateCABundle func([]byte) ([]byte, error)) (runtime.Object, error) {

--- a/pkg/certificate/configuration.go
+++ b/pkg/certificate/configuration.go
@@ -146,8 +146,8 @@ func (m *Manager) CABundle() ([]byte, error) {
 }
 
 // getServicesFromConfiguration it retrieves all the references services at
-// webhook configuration clientConfig and in case there is no service ref
-// it will refernece fake one with webhook name, mgr namespace and
+// webhook configuration clientConfig and in case there is URL instead of
+// ServiceRef it will reference fake one with webhook name, mgr namespace and
 // passing the url hostname at map value
 func (m *Manager) getServicesFromConfiguration(configuration runtime.Object) (map[types.NamespacedName][]string, error) {
 

--- a/pkg/certificate/controller.go
+++ b/pkg/certificate/controller.go
@@ -106,7 +106,7 @@ func (m *Manager) Reconcile(request reconcile.Request) (reconcile.Result, error)
 
 		// If rotate fails runtime-controller manager will re-enqueue it, so
 		// it will be retried
-		err := m.rotate()
+		err := m.rotateAll()
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed rotating certs")
 		}

--- a/pkg/certificate/controller.go
+++ b/pkg/certificate/controller.go
@@ -88,7 +88,7 @@ func (m *Manager) Reconcile(request reconcile.Request) (reconcile.Result, error)
 	reqLogger := m.log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Certificates")
 
-	elapsedToRotate := m.elapsedToRotateFromLastDeadline()
+	elapsedToRotate := m.elapsedToRotateCAFromLastDeadline()
 	elapsedToRotateServices := m.elapsedToRotateServicesFromLastDeadline()
 
 	// Ensure that this Reconcile is not called after bad changes at
@@ -115,7 +115,7 @@ func (m *Manager) Reconcile(request reconcile.Request) (reconcile.Result, error)
 		// Re-calculate elapsedToRotate since we have generated new
 		// certificates
 		m.nextRotationDeadline()
-		elapsedToRotate = m.elapsedToRotateFromLastDeadline()
+		elapsedToRotate = m.elapsedToRotateCAFromLastDeadline()
 
 		// Also recalculate it for serices certificate since they has changed
 		m.nextRotationDeadlineForServices()

--- a/pkg/certificate/controller_test.go
+++ b/pkg/certificate/controller_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Certificates controller", func() {
 						Expect(currentTLS.caCertificate).To(Equal(previousTLS.caCertificate), "shouldn't have rotate CA certificate")
 						Expect(currentTLS.caPrivateKey).To(Equal(previousTLS.caPrivateKey), "shouldn't have rotate CA key rotation")
 						Expect(currentTLS.caSecretAnnotations).To(Equal(previousTLS.caSecretAnnotations), "should containe same secret annotations")
-						Expect(currentResult.RequeueAfter).To(Equal(mgr.elapsedToRotateFromLastDeadline()), "should schedule new Reconcile after service cert rotation to rotate service cert again")
+						Expect(currentResult.RequeueAfter).To(Equal(mgr.elapsedToRotateCAFromLastDeadline()), "should schedule new Reconcile after service cert rotation to rotate service cert again")
 					})
 					Context("and called at previous RequeueAfter (ca cert rotation deadline)", func() {
 						BeforeEach(func() {

--- a/pkg/certificate/controller_test.go
+++ b/pkg/certificate/controller_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Certificates controller", func() {
 
 		It("should create TLS cert/key with proper annotation and return proper deadline", func() {
 			Expect(currentTLS.secretAnnotations).To(HaveKey(secretManagedAnnotatoinKey), "should be marked as managed by the kube-admission-webhook cert-manager")
+			Expect(currentResult.RequeueAfter).To(BeNumerically(">", time.Duration(0)), "should not be zero")
 			Expect(currentResult.RequeueAfter).To(BeNumerically("<", certsDuration), "should requeue before expiration time")
 		})
 		Context("and then called in the middle of the deadline", func() {

--- a/pkg/certificate/controller_test.go
+++ b/pkg/certificate/controller_test.go
@@ -24,7 +24,8 @@ var (
 
 var _ = Describe("Certificates controller", func() {
 	var (
-		certsDuration           = 256 * 24 * time.Hour
+		caCertDuration          = 1 * time.Hour
+		serviceCertDuration     = 30 * time.Minute
 		mgr                     *Manager
 		now                     time.Time
 		isTLSEventuallyVerified = func() AsyncAssertion {
@@ -64,7 +65,7 @@ var _ = Describe("Certificates controller", func() {
 
 	BeforeEach(func() {
 
-		mgr = NewManager(cli, expectedMutatingWebhookConfiguration.Name, MutatingWebhook, expectedNamespace.Name, certsDuration)
+		mgr = NewManager(cli, expectedMutatingWebhookConfiguration.Name, MutatingWebhook, expectedNamespace.Name, caCertDuration, serviceCertDuration)
 
 		// Freeze time
 		now = time.Now()
@@ -76,8 +77,8 @@ var _ = Describe("Certificates controller", func() {
 		deleteResources()
 	})
 	type TLS struct {
-		caBundle, certificate, privateKey []byte
-		secretAnnotations                 map[string]string
+		caBundle, caCertificate, caPrivateKey, serviceCertificate, servicePrivateKey []byte
+		caSecretAnnotations, serviceSecretAnnotations                                map[string]string
 	}
 
 	getTLS := func() TLS {
@@ -88,17 +89,26 @@ var _ = Describe("Certificates controller", func() {
 		cliConfig := obtainedWebhookConfiguration.Webhooks[0].ClientConfig
 		Expect(cliConfig.CABundle).ToNot(BeEmpty(), "should update CA budle")
 
+		obtainedCASecret := corev1.Secret{}
+		err = cli.Get(context.TODO(), types.NamespacedName{Name: expectedCASecret.Name, Namespace: expectedCASecret.Namespace}, &obtainedCASecret)
+		Expect(err).ToNot(HaveOccurred(), "should success getting CA secret")
+		Expect(obtainedCASecret.Type).To(Equal(corev1.SecretTypeOpaque), "should be a CA secret")
+		Expect(obtainedCASecret.Data).ToNot(BeEmpty(), "should contain a secret with CA key/cert")
+
 		obtainedSecret := corev1.Secret{}
 		err = cli.Get(context.TODO(), types.NamespacedName{Name: expectedSecret.Name, Namespace: expectedSecret.Namespace}, &obtainedSecret)
-		Expect(err).ToNot(HaveOccurred(), "should success getting secret")
+		Expect(err).ToNot(HaveOccurred(), "should success getting TLS secret")
 		Expect(obtainedSecret.Type).To(Equal(corev1.SecretTypeTLS), "should be a TLS secret")
 		Expect(obtainedSecret.Data).ToNot(BeEmpty(), "should contain a secret with TLS key/cert")
 
 		return TLS{
-			caBundle:          cliConfig.CABundle,
-			certificate:       obtainedSecret.Data[corev1.TLSCertKey],
-			privateKey:        obtainedSecret.Data[corev1.TLSPrivateKeyKey],
-			secretAnnotations: obtainedSecret.Annotations,
+			caBundle:                 cliConfig.CABundle,
+			caCertificate:            obtainedCASecret.Data[CACertKey],
+			caPrivateKey:             obtainedCASecret.Data[CAPrivateKeyKey],
+			caSecretAnnotations:      obtainedCASecret.Annotations,
+			serviceCertificate:       obtainedSecret.Data[corev1.TLSCertKey],
+			servicePrivateKey:        obtainedSecret.Data[corev1.TLSPrivateKeyKey],
+			serviceSecretAnnotations: obtainedSecret.Annotations,
 		}
 	}
 	Context("when reconcile is called for the first time", func() {
@@ -116,15 +126,16 @@ var _ = Describe("Certificates controller", func() {
 		})
 
 		It("should create TLS cert/key with proper annotation and return proper deadline", func() {
-			Expect(currentTLS.secretAnnotations).To(HaveKey(secretManagedAnnotatoinKey), "should be marked as managed by the kube-admission-webhook cert-manager")
+			Expect(currentTLS.caSecretAnnotations).To(HaveKey(secretManagedAnnotatoinKey), "should be marked as managed by the kube-admission-webhook cert-manager")
+			Expect(currentTLS.serviceSecretAnnotations).To(HaveKey(secretManagedAnnotatoinKey), "should be marked as managed by the kube-admission-webhook cert-manager")
 			Expect(currentResult.RequeueAfter).To(BeNumerically(">", time.Duration(0)), "should not be zero")
-			Expect(currentResult.RequeueAfter).To(BeNumerically("<", certsDuration), "should requeue before expiration time")
+			Expect(currentResult.RequeueAfter).To(Equal(mgr.elapsedToRotateServicesFromLastDeadline()), "should schedule new Reconcile after first Reconcile to rotate service cert")
 		})
-		Context("and then called in the middle of the deadline", func() {
+		Context("and then called in the middle of service cert deadline", func() {
 			BeforeEach(func() {
 				previousTLS = currentTLS
 				previousResult = currentResult
-				now = mgr.now().Add(certsDuration / 2)
+				now = mgr.now().Add(serviceCertDuration / 2)
 				mgr.now = func() time.Time { return now }
 				triple.Now = mgr.now
 				var err error
@@ -133,12 +144,13 @@ var _ = Describe("Certificates controller", func() {
 
 				currentTLS = getTLS()
 			})
-			It("should not rotate and return a reduced deadline", func() {
-				Expect(currentResult.RequeueAfter).To(BeNumerically("<", previousResult.RequeueAfter), "should subsctract 'now' from deadline at reconcile in the middle of certificate duration")
+			It("should not rotate service cert and return a reduced deadline", func() {
+				Expect(currentResult.RequeueAfter).To(BeNumerically("<", previousResult.RequeueAfter), "should subsctract 'now' from service cert deadline at reconcile in the middle of service certificate duration")
+				Expect(currentResult.RequeueAfter).To(Equal(mgr.elapsedToRotateServicesFromLastDeadline()), "should schedule new Reconcile rotate service cert")
 				Expect(currentTLS).To(Equal(previousTLS), "should not change TLS cert/key on reconcile in the middle of certificate duration")
 			})
 
-			Context("and called at previous RequeueAfter (rotation deadline)", func() {
+			Context("and called at previous RequeueAfter (service cert rotation deadline)", func() {
 				BeforeEach(func() {
 					previousTLS = currentTLS
 					previousResult = currentResult
@@ -151,23 +163,21 @@ var _ = Describe("Certificates controller", func() {
 					Expect(err).To(Succeed(), "should success reconciling")
 					currentTLS = getTLS()
 				})
-				It("should rotate TLS cert/key and return a new deadline", func() {
-					Expect(currentTLS.caBundle).ToNot(Equal(previousTLS.caBundle), "should have do a CA rotation")
-					Expect(currentTLS.certificate).ToNot(Equal(previousTLS.certificate), "should have do TLS cert rotation")
-					Expect(currentTLS.privateKey).ToNot(Equal(previousTLS.privateKey), "should have do a TLS key rotation")
-					Expect(currentTLS.secretAnnotations).To(Equal(previousTLS.secretAnnotations), "should containe same secret annotations")
-					elapsedForCleanup, err := mgr.earliestElapsedForCleanup()
-					Expect(err).To(Succeed(), "should succeed caslculating earliestElapsedForCleanup")
-					Expect(currentResult.RequeueAfter).To(Equal(elapsedForCleanup), "Reconcile at rotate should schedule next Reconcile to do the CA overlapping cleanup")
-
-					cas, err := triple.ParseCertsPEM(currentTLS.caBundle)
-					Expect(err).To(Succeed(), "should succeed parssing caBundle")
-					Expect(cas).To(HaveLen(2), "should overlap CAs")
+				It("should rotate service cert/key and return a new deadline", func() {
+					Expect(currentTLS.serviceCertificate).ToNot(Equal(previousTLS.serviceCertificate), "should have do TLS cert rotation")
+					Expect(currentTLS.servicePrivateKey).ToNot(Equal(previousTLS.servicePrivateKey), "should have do a TLS key rotation")
+					Expect(currentTLS.serviceSecretAnnotations).To(Equal(previousTLS.serviceSecretAnnotations), "should containe same secret annotations")
+					Expect(currentTLS.caBundle).To(Equal(previousTLS.caBundle), "shouldn't have rotate CABundle ")
+					Expect(currentTLS.caCertificate).To(Equal(previousTLS.caCertificate), "shouldn't have rotate CA certificate")
+					Expect(currentTLS.caPrivateKey).To(Equal(previousTLS.caPrivateKey), "shouldn't have rotate CA key rotation")
+					Expect(currentTLS.caSecretAnnotations).To(Equal(previousTLS.caSecretAnnotations), "should containe same secret annotations")
+					Expect(currentResult.RequeueAfter).To(Equal(mgr.elapsedToRotateServicesFromLastDeadline()), "should schedule new Reconcile after service cert rotation to rotate service cert again")
 				})
-				Context("and called again at previous RequeueAfter (cleanup deadline)", func() {
+				Context("and called at previous RequeueAfter (second service cert rotation deadline)", func() {
 					BeforeEach(func() {
 						previousTLS = currentTLS
 						previousResult = currentResult
+						// Emulate controller-runtime timer by adding previous RequeueAfter values to previousNow
 						now = mgr.now().Add(previousResult.RequeueAfter)
 						mgr.now = func() time.Time { return now }
 						triple.Now = mgr.now
@@ -176,92 +186,145 @@ var _ = Describe("Certificates controller", func() {
 						Expect(err).To(Succeed(), "should success reconciling")
 						currentTLS = getTLS()
 					})
-					It("should remove expired CA certificates from caBundle", func() {
-						Expect(currentTLS.caBundle).ToNot(Equal(previousTLS.caBundle), "should have do a caBundle cleanup")
-						Expect(currentTLS.certificate).To(Equal(previousTLS.certificate), "should containe same TLS cert")
-						Expect(currentTLS.privateKey).To(Equal(previousTLS.privateKey), "should containe same TLS key")
-						Expect(currentTLS.secretAnnotations).To(Equal(previousTLS.secretAnnotations), "should containe same secret annotations")
+					It("should rotate service cert/key and return a new deadline", func() {
+						Expect(currentTLS.serviceCertificate).ToNot(Equal(previousTLS.serviceCertificate), "should have do TLS cert rotation")
+						Expect(currentTLS.servicePrivateKey).ToNot(Equal(previousTLS.servicePrivateKey), "should have do a TLS key rotation")
+						Expect(currentTLS.serviceSecretAnnotations).To(Equal(previousTLS.serviceSecretAnnotations), "should containe same secret annotations")
+						Expect(currentTLS.caBundle).To(Equal(previousTLS.caBundle), "shouldn't have rotate CABundle ")
+						Expect(currentTLS.caCertificate).To(Equal(previousTLS.caCertificate), "shouldn't have rotate CA certificate")
+						Expect(currentTLS.caPrivateKey).To(Equal(previousTLS.caPrivateKey), "shouldn't have rotate CA key rotation")
+						Expect(currentTLS.caSecretAnnotations).To(Equal(previousTLS.caSecretAnnotations), "should containe same secret annotations")
+						Expect(currentResult.RequeueAfter).To(Equal(mgr.elapsedToRotateFromLastDeadline()), "should schedule new Reconcile after service cert rotation to rotate service cert again")
+					})
+					Context("and called at previous RequeueAfter (ca cert rotation deadline)", func() {
+						BeforeEach(func() {
+							previousTLS = currentTLS
+							previousResult = currentResult
+							// Emulate controller-runtime timer by adding previous RequeueAfter values to previousNow
+							now = mgr.now().Add(previousResult.RequeueAfter)
+							mgr.now = func() time.Time { return now }
+							triple.Now = mgr.now
+							var err error
+							currentResult, err = mgr.Reconcile(reconcile.Request{})
+							Expect(err).To(Succeed(), "should success reconciling")
+							currentTLS = getTLS()
+						})
+						It("should rotate CA and service certs and return new deadline", func() {
+							Expect(currentTLS.serviceCertificate).ToNot(Equal(previousTLS.serviceCertificate), "should have do TLS cert rotation")
+							Expect(currentTLS.servicePrivateKey).ToNot(Equal(previousTLS.servicePrivateKey), "should have do a TLS key rotation")
+							Expect(currentTLS.serviceSecretAnnotations).To(Equal(previousTLS.serviceSecretAnnotations), "should containe same secret annotations")
+							Expect(currentTLS.caBundle).ToNot(Equal(previousTLS.caBundle), "should have rotate CABundle ")
+							Expect(currentTLS.caCertificate).ToNot(Equal(previousTLS.caCertificate), "should have rotate CA certificate")
+							Expect(currentTLS.caPrivateKey).ToNot(Equal(previousTLS.caPrivateKey), "should have rotate CA key rotation")
 
-						cas, err := triple.ParseCertsPEM(currentTLS.caBundle)
-						Expect(err).To(Succeed(), "should succeed parssing caBundle")
-						Expect(cas).To(HaveLen(1), "should have cleandup CA bundle with expired certificates gone")
+							elapsedForCleanup, err := mgr.earliestElapsedForCleanup()
+							Expect(err).To(Succeed(), "should succeed calculating earliestElapsedForCleanup")
+							Expect(currentResult.RequeueAfter).To(Equal(elapsedForCleanup), "Reconcile at rotate should schedule next Reconcile to do the CA overlapping cleanup")
 
-						Expect(currentResult.RequeueAfter).To(Equal(mgr.elapsedToRotateFromLastDeadline()), "should schedule new Reconcile after ca overlapping cleanup to rotate current ca cert")
+							cas, err := triple.ParseCertsPEM(currentTLS.caBundle)
+							Expect(err).To(Succeed(), "should succeed parssing caBundle")
+							Expect(cas).To(HaveLen(2), "should overlap CAs")
+						})
+						Context("and called again at previous RequeueAfter (cleanup deadline)", func() {
+							BeforeEach(func() {
+								previousTLS = currentTLS
+								previousResult = currentResult
+								now = mgr.now().Add(previousResult.RequeueAfter)
+								mgr.now = func() time.Time { return now }
+								triple.Now = mgr.now
+								var err error
+								currentResult, err = mgr.Reconcile(reconcile.Request{})
+								Expect(err).To(Succeed(), "should success reconciling")
+								currentTLS = getTLS()
+							})
+							It("should remove expired CA certificates from caBundle", func() {
+								Expect(currentTLS.caBundle).ToNot(Equal(previousTLS.caBundle), "should have do a caBundle cleanup")
+								Expect(currentTLS.serviceCertificate).To(Equal(previousTLS.serviceCertificate), "should containe same TLS cert")
+								Expect(currentTLS.servicePrivateKey).To(Equal(previousTLS.servicePrivateKey), "should containe same TLS key")
+								Expect(currentTLS.serviceSecretAnnotations).To(Equal(previousTLS.serviceSecretAnnotations), "should containe same secret annotations")
+								Expect(currentTLS.caCertificate).To(Equal(previousTLS.caCertificate), "shouldn't have rotate CA certificate")
+								Expect(currentTLS.caPrivateKey).To(Equal(previousTLS.caPrivateKey), "shouldn't have rotate CA key rotation")
+
+								cas, err := triple.ParseCertsPEM(currentTLS.caBundle)
+								Expect(err).To(Succeed(), "should succeed parssing caBundle")
+								Expect(cas).To(HaveLen(1), "should have cleandup CA bundle with expired certificates gone")
+
+								Expect(currentResult.RequeueAfter).To(Equal(mgr.elapsedToRotateServicesFromLastDeadline()), "should schedule new Reconcile after ca overlapping cleanup to rotate service cert")
+							})
+						})
 					})
 				})
-
 			})
 		})
-	})
-	Context("when integrated into a controller-runtime manager and started", func() {
-		var (
-			crManager manager.Manager
-			stopCh    chan struct{}
-		)
-		BeforeEach(func(done Done) {
+		Context("when integrated into a controller-runtime manager and started", func() {
+			var (
+				crManager manager.Manager
+				stopCh    chan struct{}
+			)
+			BeforeEach(func(done Done) {
 
-			By("Creating new controller-runtime manager")
-			var err error
-			crManager, err = manager.New(testEnv.Config, manager.Options{MetricsBindAddress: "0"})
-			Expect(err).ToNot(HaveOccurred(), "should success creating controller-runtime manager")
+				By("Creating new controller-runtime manager")
+				var err error
+				crManager, err = manager.New(testEnv.Config, manager.Options{MetricsBindAddress: "0"})
+				Expect(err).ToNot(HaveOccurred(), "should success creating controller-runtime manager")
 
-			err = mgr.Add(crManager)
-			Expect(err).To(Succeed(), "should succeed adding the cert manager controller to the controller-runtime manager")
+				err = mgr.Add(crManager)
+				Expect(err).To(Succeed(), "should succeed adding the cert manager controller to the controller-runtime manager")
 
-			By("Starting controller-runtime manager")
-			stopCh = make(chan struct{})
-			go func() {
-				defer GinkgoRecover()
-				err = crManager.Start(stopCh)
-				Expect(err).To(Succeed(), "should success starting manager")
-			}()
+				By("Starting controller-runtime manager")
+				stopCh = make(chan struct{})
+				go func() {
+					defer GinkgoRecover()
+					err = crManager.Start(stopCh)
+					Expect(err).To(Succeed(), "should success starting manager")
+				}()
 
-			By("Checking that the TLS secret is created")
-			isTLSSecretEventuallyPresent().Should(BeTrue(), "should eventually have the TLS secret")
-			close(done)
+				By("Checking that the TLS secret is created")
+				isTLSSecretEventuallyPresent().Should(BeTrue(), "should eventually have the TLS secret")
+				close(done)
 
-			By("Wait a little for Reconcile to settle after mutatingwebhook configuration reconcile")
-			time.Sleep(3 * time.Second)
-		}, 10)
-		AfterEach(func() {
-			close(stopCh)
+				By("Wait a little for Reconcile to settle after mutatingwebhook configuration reconcile")
+				time.Sleep(3 * time.Second)
+			}, 10)
+			AfterEach(func() {
+				close(stopCh)
+			})
+			Context("and TLS secret is deleted", func() {
+				BeforeEach(func() {
+					By("Delete the TLS secret")
+					err := cli.Delete(context.TODO(), &expectedSecret)
+					Expect(err).To(Succeed(), "should succeed deleteing TLS secret")
+					By("Checking that the TLS secret is deleted")
+					isTLSSecretEventuallyPresent().Should(BeFalse(), "should eventually delete the TLS secret")
+				})
+				It("should re-create TLS secret", func() {
+					isTLSEventuallyVerified().Should(Succeed(), "should eventually have a TLS secret")
+				})
+			})
+			Context("and CA secret is deleted", func() {
+				BeforeEach(func() {
+					By("Delete the CA secret")
+					err := cli.Delete(context.TODO(), &expectedCASecret)
+					Expect(err).To(Succeed(), "should succeed deleteing CA secret")
+					By("Checking that the CA secret is deleted")
+					isCASecretEventuallyPresent().Should(BeFalse(), "should eventually delete the CA secret")
+				})
+				It("should re-create CA secret", func() {
+					isTLSEventuallyVerified().Should(Succeed(), "should eventually have a CA secret")
+				})
+			})
+
+			Context("and CABundle is reset", func() {
+				BeforeEach(func() {
+					obtainedWebhookConfiguration := getWebhookConfiguration()
+					obtainedWebhookConfiguration.Webhooks[0].ClientConfig.CABundle = []byte{}
+					updateWebhookConfiguration(obtainedWebhookConfiguration)
+				})
+				It("should re-create CABundle", func() {
+					isTLSEventuallyVerified().Should(Succeed(), "should eventually have a TLS secret")
+				})
+			})
 		})
-		Context("and TLS secret is deleted", func() {
-			BeforeEach(func() {
-				By("Delete the TLS secret")
-				err := cli.Delete(context.TODO(), &expectedSecret)
-				Expect(err).To(Succeed(), "should succeed deleteing TLS secret")
-				By("Checking that the TLS secret is deleted")
-				isTLSSecretEventuallyPresent().Should(BeFalse(), "should eventually delete the TLS secret")
-			})
-			It("should re-create TLS secret", func() {
-				isTLSEventuallyVerified().Should(Succeed(), "should eventually have a TLS secret")
-			})
-		})
-		Context("and CA secret is deleted", func() {
-			BeforeEach(func() {
-				By("Delete the CA secret")
-				err := cli.Delete(context.TODO(), &expectedCASecret)
-				Expect(err).To(Succeed(), "should succeed deleteing CA secret")
-				By("Checking that the CA secret is deleted")
-				isCASecretEventuallyPresent().Should(BeFalse(), "should eventually delete the CA secret")
-			})
-			It("should re-create CA secret", func() {
-				isTLSEventuallyVerified().Should(Succeed(), "should eventually have a CA secret")
-			})
-		})
-
-		Context("and CABundle is reset", func() {
-			BeforeEach(func() {
-				obtainedWebhookConfiguration := getWebhookConfiguration()
-				obtainedWebhookConfiguration.Webhooks[0].ClientConfig.CABundle = []byte{}
-				updateWebhookConfiguration(obtainedWebhookConfiguration)
-			})
-			It("should re-create CABundle", func() {
-				isTLSEventuallyVerified().Should(Succeed(), "should eventually have a TLS secret")
-			})
-		})
-
 	})
 })
 

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -158,8 +158,6 @@ func (m *Manager) rotate() error {
 		if err != nil {
 			return errors.Wrapf(err, "failed applying TLS secret %s", service)
 		}
-		// We have only
-		break
 	}
 
 	return nil

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -94,12 +94,12 @@ func NewManager(
 ) *Manager {
 
 	m := &Manager{
-		client:               client,
-		webhookName:          webhookName,
-		webhookType:          webhookType,
-		namespace:            namespace,
-		now:                  time.Now,
-		caCertDuration:       caCertDuration,
+		client:              client,
+		webhookName:         webhookName,
+		webhookType:         webhookType,
+		namespace:           namespace,
+		now:                 time.Now,
+		caCertDuration:      caCertDuration,
 		serviceCertDuration: serviceCertDuration,
 		log: logf.Log.WithName("certificate/manager").
 			WithValues("webhookType", webhookType, "webhookName", webhookName),
@@ -162,7 +162,7 @@ func (m *Manager) rotateAll() error {
 }
 
 func (m *Manager) rotateServices() error {
-	m.log.Info("Rotating CA cert/key")
+	m.log.Info("Rotating Services cert/key")
 
 	webhook, err := m.readyWebhookConfiguration()
 	if err != nil {

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -275,7 +275,7 @@ func (m *Manager) nextRotationDeadlineForCert(certificate *x509.Certificate) tim
 	return deadline
 }
 
-func (m *Manager) elapsedToRotateFromLastDeadline() time.Duration {
+func (m *Manager) elapsedToRotateCAFromLastDeadline() time.Duration {
 	deadline := m.now()
 
 	// If deadline was previously calculated return it, else do the
@@ -287,7 +287,7 @@ func (m *Manager) elapsedToRotateFromLastDeadline() time.Duration {
 	}
 	now := m.now()
 	elapsedToRotate := deadline.Sub(now)
-	m.log.Info(fmt.Sprintf("elapsedToRotateFromLastDeadline {now: %s, deadline: %s, elapsedToRotate: %s}", now, deadline, elapsedToRotate))
+	m.log.Info(fmt.Sprintf("elapsedToRotateCAFromLastDeadline {now: %s, deadline: %s, elapsedToRotate: %s}", now, deadline, elapsedToRotate))
 	return elapsedToRotate
 }
 

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -32,6 +32,10 @@ type Manager struct {
 	// webhookType The Mutating or Validating Webhook configuration type
 	webhookType WebhookType
 
+	// The namespace where ca secret will be created or service secrets
+	// for ClientConfig that has URL instead of ServiceRef
+	namespace string
+
 	// now is an artifact to do some unit testing without waiting for
 	// expiration time.
 	now func() time.Time
@@ -81,6 +85,7 @@ func NewManager(
 	client client.Client,
 	webhookName string,
 	webhookType WebhookType,
+	namespace string,
 	certsDuration time.Duration,
 ) *Manager {
 
@@ -88,6 +93,7 @@ func NewManager(
 		client:        client,
 		webhookName:   webhookName,
 		webhookType:   webhookType,
+		namespace:     namespace,
 		now:           time.Now,
 		certsDuration: certsDuration,
 		log: logf.Log.WithName("certificate/manager").
@@ -320,9 +326,9 @@ func (m *Manager) verifyTLS() error {
 			secretKey.Namespace = service.Namespace
 		} else {
 			// If it uses directly URL create a secret with webhookName and
-			// default namespace
+			// mgr namespace
 			secretKey.Name = m.webhookName
-			secretKey.Namespace = "default"
+			secretKey.Namespace = m.namespace
 		}
 		err = m.verifyTLSSecret(secretKey, caKeyPair, clientConfig.CABundle)
 		if err != nil {

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -252,6 +252,11 @@ func (m *Manager) verifyTLS() error {
 		return errors.Wrap(err, "failed to reading configuration")
 	}
 
+	caKeyPair, err := m.getCAKeyPair()
+	if err != nil {
+		return errors.Wrap(err, "failed getting CA keypair from secret to verify TLS")
+	}
+
 	for _, clientConfig := range m.clientConfigList(webhookConf) {
 		service := clientConfig.Service
 		secretKey := types.NamespacedName{}
@@ -266,7 +271,7 @@ func (m *Manager) verifyTLS() error {
 			secretKey.Name = m.webhookName
 			secretKey.Namespace = "default"
 		}
-		err = m.verifyTLSSecret(secretKey, clientConfig.CABundle)
+		err = m.verifyTLSSecret(secretKey, caKeyPair, clientConfig.CABundle)
 		if err != nil {
 			return errors.Wrapf(err, "failed verifying TLS secret %s", secretKey)
 		}

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -23,7 +23,7 @@ var _ = Describe("certificate manager", func() {
 		notAfter     time.Duration
 		shouldRotate bool
 	}
-	DescribeTable("nexrtRotationDeadlineForCert",
+	DescribeTable("nextRotationDeadlineForCert",
 		func(c nextRotationDeadlineForCertCase) {
 			log := logf.Log.WithName("webhook/server/certificate/manager_test")
 			now := time.Now()
@@ -97,7 +97,7 @@ var _ = Describe("certificate manager", func() {
 	newManager := func() *Manager {
 
 		manager := NewManager(cli, expectedMutatingWebhookConfiguration.ObjectMeta.Name, MutatingWebhook, time.Hour)
-		err := manager.rotate()
+		err := manager.rotateAll()
 		ExpectWithOffset(1, err).To(Succeed(), "should success rotating certs")
 
 		return manager

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -96,7 +96,7 @@ var _ = Describe("certificate manager", func() {
 
 	newManager := func() *Manager {
 
-		manager := NewManager(cli, expectedMutatingWebhookConfiguration.ObjectMeta.Name, MutatingWebhook, expectedNamespace.Name, time.Hour)
+		manager := NewManager(cli, expectedMutatingWebhookConfiguration.ObjectMeta.Name, MutatingWebhook, expectedNamespace.Name, time.Hour, time.Hour)
 		err := manager.rotateAll()
 		ExpectWithOffset(1, err).To(Succeed(), "should success rotating certs")
 

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -116,7 +116,7 @@ var _ = Describe("certificate manager", func() {
 	loadCASecret := func(manager *Manager) corev1.Secret {
 		secretKey := types.NamespacedName{
 			Namespace: "default",
-			Name:      expectedMutatingWebhookConfiguration.Name,
+			Name:      expectedMutatingWebhookConfiguration.Name + "-ca",
 		}
 		obtainedSecret := corev1.Secret{}
 		err := manager.client.Get(context.TODO(), secretKey, &obtainedSecret)

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -96,7 +96,7 @@ var _ = Describe("certificate manager", func() {
 
 	newManager := func() *Manager {
 
-		manager := NewManager(cli, expectedMutatingWebhookConfiguration.ObjectMeta.Name, MutatingWebhook, time.Hour)
+		manager := NewManager(cli, expectedMutatingWebhookConfiguration.ObjectMeta.Name, MutatingWebhook, expectedNamespace.Name, time.Hour)
 		err := manager.rotateAll()
 		ExpectWithOffset(1, err).To(Succeed(), "should success rotating certs")
 
@@ -115,8 +115,8 @@ var _ = Describe("certificate manager", func() {
 
 	loadCASecret := func(manager *Manager) corev1.Secret {
 		secretKey := types.NamespacedName{
-			Namespace: "default",
-			Name:      expectedMutatingWebhookConfiguration.Name + "-ca",
+			Namespace: expectedCASecret.Namespace,
+			Name:      expectedCASecret.Name,
 		}
 		obtainedSecret := corev1.Secret{}
 		err := manager.client.Get(context.TODO(), secretKey, &obtainedSecret)

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 var _ = Describe("certificate manager", func() {
-	type setRotationDeadlineCase struct {
+	type nextRotationDeadlineForCertCase struct {
 		notBefore    time.Duration
 		notAfter     time.Duration
 		shouldRotate bool
 	}
-	DescribeTable("SetRotationDeadline",
-		func(c setRotationDeadlineCase) {
+	DescribeTable("nexrtRotationDeadlineForCert",
+		func(c nextRotationDeadlineForCertCase) {
 			log := logf.Log.WithName("webhook/server/certificate/manager_test")
 			now := time.Now()
 			notAfter := now.Add(c.notAfter)
@@ -47,42 +47,42 @@ var _ = Describe("certificate manager", func() {
 			Expect(deadline).To(Equal(lowerBound), fmt.Sprintf("should match deadline for notBefore %v and notAfter %v", notBefore, notAfter))
 
 		},
-		Entry("just issued, still good", setRotationDeadlineCase{
+		Entry("just issued, still good", nextRotationDeadlineForCertCase{
 			notBefore:    -1 * time.Hour,
 			notAfter:     99 * time.Hour,
 			shouldRotate: false,
 		}),
-		Entry("half way expired, still good", setRotationDeadlineCase{
+		Entry("half way expired, still good", nextRotationDeadlineForCertCase{
 			notBefore:    -24 * time.Hour,
 			notAfter:     24 * time.Hour,
 			shouldRotate: false,
 		}),
-		Entry("mostly expired, still good", setRotationDeadlineCase{
+		Entry("mostly expired, still good", nextRotationDeadlineForCertCase{
 			notBefore:    -69 * time.Hour,
 			notAfter:     31 * time.Hour,
 			shouldRotate: false,
 		}),
-		Entry("just about expired, should rotate", setRotationDeadlineCase{
+		Entry("just about expired, should rotate", nextRotationDeadlineForCertCase{
 			notBefore:    -91 * time.Hour,
 			notAfter:     9 * time.Hour,
 			shouldRotate: true,
 		}),
-		Entry("nearly expired, should rotate", setRotationDeadlineCase{
+		Entry("nearly expired, should rotate", nextRotationDeadlineForCertCase{
 			notBefore:    -99 * time.Hour,
 			notAfter:     1 * time.Hour,
 			shouldRotate: true,
 		}),
-		Entry("already expired, should rotate", setRotationDeadlineCase{
+		Entry("already expired, should rotate", nextRotationDeadlineForCertCase{
 			notBefore:    -10 * time.Hour,
 			notAfter:     -1 * time.Hour,
 			shouldRotate: true,
 		}),
-		Entry("long duration", setRotationDeadlineCase{
+		Entry("long duration", nextRotationDeadlineForCertCase{
 			notBefore:    -6 * 30 * 24 * time.Hour,
 			notAfter:     6 * 30 * 24 * time.Hour,
 			shouldRotate: true,
 		}),
-		Entry("short duration", setRotationDeadlineCase{
+		Entry("short duration", nextRotationDeadlineForCertCase{
 			notBefore:    -30 * time.Second,
 			notAfter:     30 * time.Second,
 			shouldRotate: true,

--- a/pkg/certificate/secret.go
+++ b/pkg/certificate/secret.go
@@ -130,18 +130,18 @@ func (m *Manager) verifyTLSSecret(secretKey types.NamespacedName, caKeyPair *tri
 }
 
 func (m *Manager) getCAKeyPair() (*triple.KeyPair, error) {
-	secret := corev1.Secret{}
-	err := m.get(m.caSecretKey(), &secret)
+	caSecret := corev1.Secret{}
+	err := m.get(m.caSecretKey(), &caSecret)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed reading ca secret %s", m.caSecretKey())
 	}
 
-	caPrivateKeyPEM, found := secret.Data[CAPrivateKeyKey]
+	caPrivateKeyPEM, found := caSecret.Data[CAPrivateKeyKey]
 	if !found {
 		return nil, errors.Wrapf(err, "ca private key not found at secret %s", m.caSecretKey())
 	}
 
-	caCertPEM, found := secret.Data[CACertKey]
+	caCertPEM, found := caSecret.Data[CACertKey]
 	if !found {
 		return nil, errors.Wrapf(err, "ca cert not found at secret %s", m.caSecretKey())
 	}

--- a/pkg/certificate/secret.go
+++ b/pkg/certificate/secret.go
@@ -189,5 +189,5 @@ func (m *Manager) getTLSKeyPair(secretKey types.NamespacedName) (*triple.KeyPair
 
 //FIXME: Is this default/webhookname good key for ca secret
 func (m *Manager) caSecretKey() types.NamespacedName {
-	return types.NamespacedName{Namespace: "default", Name: m.webhookName + "-ca"}
+	return types.NamespacedName{Namespace: m.namespace, Name: m.webhookName + "-ca"}
 }

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -33,13 +33,13 @@ type ServerModifier func(w *webhook.Server)
 
 // Add creates a new Conditions Mutating Webhook and adds it to the Manager. The Manager will set fields on the Webhook
 // and Start it when the Manager is Started.
-func New(client client.Client, webhookName string, webhookType certificate.WebhookType, caRotateInterval time.Duration, serverOpts ...ServerModifier) *Server {
+func New(client client.Client, webhookName string, webhookType certificate.WebhookType, namespace string, caRotateInterval time.Duration, serverOpts ...ServerModifier) *Server {
 	s := &Server{
 		webhookServer: &webhook.Server{
 			Port:    8443,
 			CertDir: "/etc/webhook/certs/",
 		},
-		certManager: certificate.NewManager(client, webhookName, webhookType, caRotateInterval),
+		certManager: certificate.NewManager(client, webhookName, webhookType, namespace, caRotateInterval),
 		log:         logf.Log.WithName("webhook/server"),
 	}
 	s.UpdateOpts(serverOpts...)

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -33,13 +33,13 @@ type ServerModifier func(w *webhook.Server)
 
 // Add creates a new Conditions Mutating Webhook and adds it to the Manager. The Manager will set fields on the Webhook
 // and Start it when the Manager is Started.
-func New(client client.Client, webhookName string, webhookType certificate.WebhookType, namespace string, caRotateInterval time.Duration, serverOpts ...ServerModifier) *Server {
+func New(client client.Client, webhookName string, webhookType certificate.WebhookType, namespace string, caRotateInterval time.Duration, certRotateInterval time.Duration, serverOpts ...ServerModifier) *Server {
 	s := &Server{
 		webhookServer: &webhook.Server{
 			Port:    8443,
 			CertDir: "/etc/webhook/certs/",
 		},
-		certManager: certificate.NewManager(client, webhookName, webhookType, namespace, caRotateInterval),
+		certManager: certificate.NewManager(client, webhookName, webhookType, namespace, caRotateInterval, certRotateInterval),
 		log:         logf.Log.WithName("webhook/server"),
 	}
 	s.UpdateOpts(serverOpts...)

--- a/pkg/webhook/server/server_suite_test.go
+++ b/pkg/webhook/server/server_suite_test.go
@@ -66,7 +66,7 @@ var (
 
 	expectedSecret = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
+			Namespace: expectedNamespace.Name,
 			Name:      "foowebhook",
 		},
 	}

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Webhook server", func() {
 				return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 			}
 
-			server := New(cli, expectedMutatingWebhookConfiguration.Name, certificate.MutatingWebhook, expectedNamespace.Name, certificate.OneYearDuration,
+			server := New(cli, expectedMutatingWebhookConfiguration.Name, certificate.MutatingWebhook, expectedNamespace.Name, certificate.OneYearDuration, certificate.OneYearDuration,
 				WithCertDir(certDir),
 				WithPort(freePort),
 				WithHook("/mutatepod",

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Webhook server", func() {
 					}
 					return false, err
 				}
-				return true, nil
+				return len(obtainedSecret.Data[corev1.TLSCertKey]) > 0 && len(obtainedSecret.Data[corev1.TLSPrivateKeyKey]) > 0, nil
 			}, 5*time.Second, 1*time.Second).Should(BeTrue(), "should eventually have a TLS secret")
 
 			By("Dump tls.key and tls.crt into webhook server certDir")

--- a/test/pod/main.go
+++ b/test/pod/main.go
@@ -75,8 +75,8 @@ func main() {
 
 	// Setup webhooks
 	entryLog.Info("setting up webhook server")
-	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.MutatingWebhook, certificate.OneYearDuration)
-	validatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.ValidatingWebhook, certificate.OneYearDuration)
+	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.MutatingWebhook, "mynamespace", certificate.OneYearDuration, certificate.OneYearDuration)
+	validatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.ValidatingWebhook, "mynamespace", certificate.OneYearDuration, certificate.OneYearDuration)
 
 	entryLog.Info("registering webhooks to the webhook server")
 	mutatingWebhookServer.UpdateOpts(webhookserver.WithHook("/mutate-v1-pod", &webhook.Admission{Handler: &podAnnotator{Client: mgr.GetClient()}}))

--- a/test/pod/main.go
+++ b/test/pod/main.go
@@ -75,8 +75,8 @@ func main() {
 
 	// Setup webhooks
 	entryLog.Info("setting up webhook server")
-	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.MutatingWebhook)
-	validatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.ValidatingWebhook)
+	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.MutatingWebhook, certificate.OneYearDuration)
+	validatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.ValidatingWebhook, certificate.OneYearDuration)
 
 	entryLog.Info("registering webhooks to the webhook server")
 	mutatingWebhookServer.UpdateOpts(webhookserver.WithHook("/mutate-v1-pod", &webhook.Admission{Handler: &podAnnotator{Client: mgr.GetClient()}}))


### PR DESCRIPTION
This PR add a new "knob" `certRotationInterval` to specify the service certificate expiration time, the current version at master use the value at `CARotationInterval`. 

To accomplish this new secret is created with key `[namespace]/[webhookname]-ca`  the `namespace` and `webhookname` are the one passed to the webhook server.

Also a bug is fixed, the service secret was being re-constructed per webhook since it was just iterating instead of listing services and create new secret per each one.