### PR TITLE
Use a struct to group certificate options

### DIFF
--- a/pkg/certificate/controller_test.go
+++ b/pkg/certificate/controller_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Certificates controller", func() {
 
 	BeforeEach(func() {
 
-		mgr = NewManager(cli, expectedMutatingWebhookConfiguration.Name, MutatingWebhook, expectedNamespace.Name, caCertDuration, serviceCertDuration)
+		mgr = NewManager(cli, Options{WebhookName: expectedMutatingWebhookConfiguration.Name, WebhookType: MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: caCertDuration, CertRotateInterval: serviceCertDuration})
 
 		// Freeze time
 		now = time.Now()

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -96,7 +96,7 @@ var _ = Describe("certificate manager", func() {
 
 	newManager := func() *Manager {
 
-		manager := NewManager(cli, expectedMutatingWebhookConfiguration.ObjectMeta.Name, MutatingWebhook, expectedNamespace.Name, time.Hour, time.Hour)
+		manager := NewManager(cli, Options{WebhookName: expectedMutatingWebhookConfiguration.ObjectMeta.Name, WebhookType: MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: time.Hour, CertRotateInterval: time.Hour})
 		err := manager.rotateAll()
 		ExpectWithOffset(1, err).To(Succeed(), "should success rotating certs")
 

--- a/pkg/certificate/options.go
+++ b/pkg/certificate/options.go
@@ -1,0 +1,49 @@
+package certificate
+
+import (
+	"time"
+)
+
+type WebhookType string
+
+const (
+	MutatingWebhook   WebhookType = "Mutating"
+	ValidatingWebhook WebhookType = "Validating"
+	OneYearDuration               = 365 * 24 * time.Hour
+)
+
+type Options struct {
+
+	// webhookName The Mutating or Validating Webhook configuration name
+	WebhookName string
+
+	// webhookType The Mutating or Validating Webhook configuration type
+	WebhookType WebhookType
+
+	// The namespace where ca secret will be created or service secrets
+	// for ClientConfig that has URL instead of ServiceRef
+	Namespace string
+
+	// CARotateInterval configurated duration for CA and certificate
+	CARotateInterval time.Duration
+
+	// CertRotateInterval configurated duration for of service certificate
+	// the the webhook configuration is referencing different services all
+	// of them will share the same duration
+	CertRotateInterval time.Duration
+}
+
+func (o *Options) setDefaults() {
+
+	if o.WebhookType == "" {
+		o.WebhookType = MutatingWebhook
+	}
+
+	if o.CARotateInterval == 0 {
+		o.CARotateInterval = OneYearDuration
+	}
+
+	if o.CertRotateInterval == 0 {
+		o.CertRotateInterval = o.CARotateInterval
+	}
+}

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -33,13 +33,13 @@ type ServerModifier func(w *webhook.Server)
 
 // Add creates a new Conditions Mutating Webhook and adds it to the Manager. The Manager will set fields on the Webhook
 // and Start it when the Manager is Started.
-func New(client client.Client, webhookName string, webhookType certificate.WebhookType, namespace string, caRotateInterval time.Duration, certRotateInterval time.Duration, serverOpts ...ServerModifier) *Server {
+func New(client client.Client, certificateOpts certificate.Options, serverOpts ...ServerModifier) *Server {
 	s := &Server{
 		webhookServer: &webhook.Server{
 			Port:    8443,
 			CertDir: "/etc/webhook/certs/",
 		},
-		certManager: certificate.NewManager(client, webhookName, webhookType, namespace, caRotateInterval, certRotateInterval),
+		certManager: certificate.NewManager(client, certificateOpts),
 		log:         logf.Log.WithName("webhook/server"),
 	}
 	s.UpdateOpts(serverOpts...)

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Webhook server", func() {
 				return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 			}
 
-			server := New(cli, expectedMutatingWebhookConfiguration.Name, certificate.MutatingWebhook, expectedNamespace.Name, certificate.OneYearDuration, certificate.OneYearDuration,
+			server := New(cli, certificate.Options{WebhookName: expectedMutatingWebhookConfiguration.Name, WebhookType: certificate.MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration},
 				WithCertDir(certDir),
 				WithPort(freePort),
 				WithHook("/mutatepod",

--- a/test/pod/main.go
+++ b/test/pod/main.go
@@ -75,8 +75,8 @@ func main() {
 
 	// Setup webhooks
 	entryLog.Info("setting up webhook server")
-	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.MutatingWebhook, "mynamespace", certificate.OneYearDuration, certificate.OneYearDuration)
-	validatingWebhookServer := webhookserver.New(mgr.GetClient(), "test-webhook", certificate.ValidatingWebhook, "mynamespace", certificate.OneYearDuration, certificate.OneYearDuration)
+	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), certificate.Options{WebhookName: "test-webhook", WebhookType: certificate.MutatingWebhook, Namespace: "mynamespace", CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration})
+	validatingWebhookServer := webhookserver.New(mgr.GetClient(), certificate.Options{WebhookName: "test-webhook", WebhookType: certificate.ValidatingWebhook, Namespace: "mynamespace", CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration})
 
 	entryLog.Info("registering webhooks to the webhook server")
 	mutatingWebhookServer.UpdateOpts(webhookserver.WithHook("/mutate-v1-pod", &webhook.Admission{Handler: &podAnnotator{Client: mgr.GetClient()}}))


### PR DESCRIPTION
The certificate options are starting to grow too much let's group them together
to pass the struct directly from client to certificate manager.

Signed-off-by: Quique Llorente <ellorent@redhat.com>