### PR TITLE
Implement CAOverlapInterval options to ditch old CAs from CABunlde

### DIFF
--- a/pkg/certificate/cleanup.go
+++ b/pkg/certificate/cleanup.go
@@ -35,14 +35,18 @@ func (m *Manager) earliestCleanupDeadline() (time.Time, error) {
 }
 
 // earliestCleanupDeadlineForCACerts will inspect CA certificates
-// select the deadline based on certificate that is going to expire
-// sooner so cleanup is triggered then
+// select the deadline based on certificate NotBefore + caOverlapDuration
+// returning the daedline that is going to happend sooner
 func (m *Manager) earliestCleanupDeadlineForCerts(certificates []*x509.Certificate) time.Time {
-
 	var selectedCertificate *x509.Certificate
 
+	// There is no overlap just return expiration time
+	if len(certificates) == 1 {
+		return certificates[0].NotAfter
+	}
+
 	for _, certificate := range certificates {
-		if selectedCertificate == nil || certificate.NotAfter.Before(selectedCertificate.NotAfter) {
+		if selectedCertificate == nil || certificate.NotBefore.Before(selectedCertificate.NotBefore) {
 			selectedCertificate = certificate
 		}
 	}
@@ -50,18 +54,18 @@ func (m *Manager) earliestCleanupDeadlineForCerts(certificates []*x509.Certifica
 		return m.now()
 	}
 
-	return selectedCertificate.NotAfter
+	// Add the overlap duration since is the time certs are going to be living
+	// add CABundle
+	return selectedCertificate.NotBefore.Add(m.caOverlapDuration)
 }
 
 func (m *Manager) cleanUpCABundle() error {
-	logger := m.log.WithName("cleanUpCABundle")
-	logger.Info("Cleaning up expired certificates at CA bundle")
 	_, err := m.updateWebhookCABundleWithFunc(func([]byte) ([]byte, error) {
 		cas, err := m.getCACertsFromCABundle()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed getting ca certs to start cleanup")
 		}
-		cleanedCAs := m.cleanUpExpiredCertificates(cas)
+		cleanedCAs := m.cleanUpCertificates(cas)
 		pem := triple.EncodeCertsPEM(cleanedCAs)
 		return pem, nil
 	})
@@ -72,14 +76,35 @@ func (m *Manager) cleanUpCABundle() error {
 	return nil
 }
 
-func (m *Manager) cleanUpExpiredCertificates(certificates []*x509.Certificate) []*x509.Certificate {
+func (m *Manager) cleanUpCertificates(certificates []*x509.Certificate) []*x509.Certificate {
+	logger := m.log.WithName("cleanUpCertificates")
+	logger.Info("Cleaning up expired or beyond overlap duration limit at CA bundle")
+	// There is no overlap
+	if len(certificates) <= 1 {
+		return certificates
+	}
+
 	now := m.now()
 	// create a zero-length slice with the same underlying array
 	cleanedUpCertificates := certificates[:0]
-	for _, certificate := range certificates {
-		if certificate.NotAfter.After(now) {
-			cleanedUpCertificates = append(cleanedUpCertificates, certificate)
+	for i, certificate := range certificates {
+		logger.Info("Checking certificate for cleanup", "now", now, "caOverlapDuration", m.caOverlapDuration, "NotBefore", certificate.NotBefore, "NotAfter", certificate.NotAfter)
+
+		// Expired certificate are cleaned up
+		caExpirationDate := certificate.NotAfter
+		if now.After(caExpirationDate) {
+			logger.Info("Cleaning up expired certificate", "now", now, "NotBefore", certificate.NotBefore, "NotAfter", certificate.NotAfter)
+			continue
 		}
+
+		// Clean up certificates that pass CA Overlap Duration limit,
+		// except for the last appended one (i.e. the last generated from a rotation) since we need at least one valid certificate
+		caOverlapDate := certificate.NotBefore.Add(m.caOverlapDuration)
+		if i != len(certificates)-1 && !now.Before(caOverlapDate) {
+			logger.Info("Cleaning up certificate beyond CA overlap duration", "now", now, "caOverlapDuration", m.caOverlapDuration, "NotBefore", certificate.NotBefore, "NotAfter", certificate.NotAfter)
+			continue
+		}
+		cleanedUpCertificates = append(cleanedUpCertificates, certificate)
 	}
 	return cleanedUpCertificates
 }

--- a/pkg/certificate/controller_test.go
+++ b/pkg/certificate/controller_test.go
@@ -65,8 +65,9 @@ var _ = Describe("Certificates controller", func() {
 
 	BeforeEach(func() {
 
-		mgr = NewManager(cli, Options{WebhookName: expectedMutatingWebhookConfiguration.Name, WebhookType: MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: caCertDuration, CertRotateInterval: serviceCertDuration})
-
+		var err error
+		mgr, err = NewManager(cli, Options{WebhookName: expectedMutatingWebhookConfiguration.Name, WebhookType: MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: caCertDuration, CertRotateInterval: serviceCertDuration})
+		Expect(err).To(Succeed(), "should succeed constructing certificate manager")
 		// Freeze time
 		now = time.Now()
 
@@ -120,6 +121,7 @@ var _ = Describe("Certificates controller", func() {
 			mgr.now = func() time.Time { return now }
 			triple.Now = mgr.now
 			var err error
+			By("Reconcile for the first time")
 			currentResult, err = mgr.Reconcile(reconcile.Request{})
 			Expect(err).To(Succeed(), "should success reconciling")
 			currentTLS = getTLS()
@@ -139,6 +141,7 @@ var _ = Describe("Certificates controller", func() {
 				mgr.now = func() time.Time { return now }
 				triple.Now = mgr.now
 				var err error
+				By("Reconcile in the middle of service cert deadline")
 				currentResult, err = mgr.Reconcile(reconcile.Request{})
 				Expect(err).To(Succeed(), "should success reconciling")
 
@@ -159,6 +162,7 @@ var _ = Describe("Certificates controller", func() {
 					mgr.now = func() time.Time { return now }
 					triple.Now = mgr.now
 					var err error
+					By("Reconcile at service cert rotation deadline")
 					currentResult, err = mgr.Reconcile(reconcile.Request{})
 					Expect(err).To(Succeed(), "should success reconciling")
 					currentTLS = getTLS()
@@ -182,6 +186,7 @@ var _ = Describe("Certificates controller", func() {
 						mgr.now = func() time.Time { return now }
 						triple.Now = mgr.now
 						var err error
+						By("Reconcile at second service cert rotation deadline")
 						currentResult, err = mgr.Reconcile(reconcile.Request{})
 						Expect(err).To(Succeed(), "should success reconciling")
 						currentTLS = getTLS()
@@ -205,6 +210,7 @@ var _ = Describe("Certificates controller", func() {
 							mgr.now = func() time.Time { return now }
 							triple.Now = mgr.now
 							var err error
+							By("Reconcile at ca cert rotation deadline")
 							currentResult, err = mgr.Reconcile(reconcile.Request{})
 							Expect(err).To(Succeed(), "should success reconciling")
 							currentTLS = getTLS()
@@ -233,6 +239,7 @@ var _ = Describe("Certificates controller", func() {
 								mgr.now = func() time.Time { return now }
 								triple.Now = mgr.now
 								var err error
+								By("Reconcile at cleanup deadline")
 								currentResult, err = mgr.Reconcile(reconcile.Request{})
 								Expect(err).To(Succeed(), "should success reconciling")
 								currentTLS = getTLS()

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -48,6 +48,9 @@ type Manager struct {
 	// caCertDuration Options.CARotateInterval
 	caCertDuration time.Duration
 
+	// caCertDuration Options.CAOverlapInterval
+	caOverlapDuration time.Duration
+
 	// serviceCertDuration Options.CertRotateInterval
 	serviceCertDuration time.Duration
 
@@ -76,9 +79,11 @@ type Manager struct {
 func NewManager(
 	client client.Client,
 	options Options,
-) *Manager {
-
-	options.setDefaults()
+) (*Manager, error) {
+	err := options.setDefaultsAndValidate()
+	if err != nil {
+		return nil, err
+	}
 
 	m := &Manager{
 		client:              client,
@@ -87,11 +92,12 @@ func NewManager(
 		namespace:           options.Namespace,
 		now:                 time.Now,
 		caCertDuration:      options.CARotateInterval,
+		caOverlapDuration:   options.CAOverlapInterval,
 		serviceCertDuration: options.CertRotateInterval,
 		log: logf.Log.WithName("certificate/manager").
 			WithValues("webhookType", options.WebhookType, "webhookName", options.WebhookName),
 	}
-	return m
+	return m, nil
 }
 
 func (m *Manager) getCACertsFromCABundle() ([]*x509.Certificate, error) {

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -96,8 +96,9 @@ var _ = Describe("certificate manager", func() {
 
 	newManager := func() *Manager {
 
-		manager := NewManager(cli, Options{WebhookName: expectedMutatingWebhookConfiguration.ObjectMeta.Name, WebhookType: MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: time.Hour, CertRotateInterval: time.Hour})
-		err := manager.rotateAll()
+		manager, err := NewManager(cli, Options{WebhookName: expectedMutatingWebhookConfiguration.ObjectMeta.Name, WebhookType: MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: time.Hour, CertRotateInterval: time.Hour})
+		ExpectWithOffset(1, err).To(Succeed(), "should success creating certificate manager")
+		err = manager.rotateAll()
 		ExpectWithOffset(1, err).To(Succeed(), "should success rotating certs")
 
 		return manager

--- a/pkg/certificate/options.go
+++ b/pkg/certificate/options.go
@@ -1,6 +1,7 @@
 package certificate
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -27,23 +28,66 @@ type Options struct {
 	// CARotateInterval configurated duration for CA and certificate
 	CARotateInterval time.Duration
 
+	// CAOverlapInterval the duration of CA Certificates at CABundle if
+	// not set it will default to CARotateInterval
+	CAOverlapInterval time.Duration
+
 	// CertRotateInterval configurated duration for of service certificate
 	// the the webhook configuration is referencing different services all
 	// of them will share the same duration
 	CertRotateInterval time.Duration
 }
 
-func (o *Options) setDefaults() {
+func (o *Options) validate() error {
+	if o.WebhookName == "" {
+		return fmt.Errorf("failed validating certificate options, 'WebhookName' field is missing")
+	}
+	if o.Namespace == "" {
+		return fmt.Errorf("failed validating certificate options, 'Namespace' field is missing")
+	}
 
+	if o.CAOverlapInterval > o.CARotateInterval {
+		return fmt.Errorf("failed validating certificate options, 'CAOverlapInterval' has to be <= 'CARotateInterval'")
+	}
+
+	if o.CertRotateInterval > o.CARotateInterval {
+		return fmt.Errorf("failed validating certificate options, 'CertRotateInterval' has to be <= 'CARotateInterval'")
+	}
+
+	if o.WebhookType != MutatingWebhook && o.WebhookType != ValidatingWebhook {
+		return fmt.Errorf("failed validating certificate options, 'WebhookType' has to be %s or %s", MutatingWebhook, ValidatingWebhook)
+	}
+
+	return nil
+
+}
+
+func (o Options) withDefaults() Options {
+	withDefaultsOptions := o
 	if o.WebhookType == "" {
-		o.WebhookType = MutatingWebhook
+		withDefaultsOptions.WebhookType = MutatingWebhook
 	}
 
 	if o.CARotateInterval == 0 {
-		o.CARotateInterval = OneYearDuration
+		withDefaultsOptions.CARotateInterval = OneYearDuration
+	}
+
+	if o.CAOverlapInterval == 0 {
+		withDefaultsOptions.CAOverlapInterval = withDefaultsOptions.CARotateInterval
 	}
 
 	if o.CertRotateInterval == 0 {
-		o.CertRotateInterval = o.CARotateInterval
+		withDefaultsOptions.CertRotateInterval = withDefaultsOptions.CARotateInterval
 	}
+	return withDefaultsOptions
+}
+
+func (o *Options) setDefaultsAndValidate() error {
+	withDefaultsOptions := o.withDefaults()
+	err := withDefaultsOptions.validate()
+	if err != nil {
+		return err
+	}
+	*o = withDefaultsOptions
+	return nil
 }

--- a/pkg/certificate/options_test.go
+++ b/pkg/certificate/options_test.go
@@ -1,0 +1,182 @@
+package certificate
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Certificate Options", func() {
+	type setDefaultsAndValidateCase struct {
+		options         Options
+		expectedOptions Options
+		isValid         bool
+	}
+	DescribeTable("setDefaultsAndValidate",
+		func(c setDefaultsAndValidateCase) {
+			err := c.options.setDefaultsAndValidate()
+			if c.isValid {
+				Expect(err).To(Succeed(), "should succeed validating the options")
+			} else {
+				Expect(err).ToNot(Succeed(), "should not succeed validating the options")
+			}
+			Expect(c.options).To(Equal(c.expectedOptions), "should equal expected options after setting defaults")
+		},
+		Entry("Empty options should be invalid since it's missing webhook name and namespace and set defaults", setDefaultsAndValidateCase{
+			isValid: false,
+		}),
+		Entry("Just passing webhook name options should be invalid since it's missing namespace and set default", setDefaultsAndValidateCase{
+			options: Options{
+				WebhookName: "MyWebhook",
+			},
+			expectedOptions: Options{
+				WebhookName: "MyWebhook",
+			},
+			isValid: false,
+		}),
+		Entry("Passing webhook name and namespace options should be valid and set default", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:   "MyNamespace",
+				WebhookName: "MyWebhook",
+			},
+			expectedOptions: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				WebhookType:        MutatingWebhook,
+				CARotateInterval:   OneYearDuration,
+				CAOverlapInterval:  OneYearDuration,
+				CertRotateInterval: OneYearDuration,
+			},
+			isValid: true,
+		}),
+		Entry("Passing WebhookType ValidatingWebhook options should be valid", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:   "MyNamespace",
+				WebhookName: "MyWebhook",
+				WebhookType: ValidatingWebhook,
+			},
+			expectedOptions: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				WebhookType:        ValidatingWebhook,
+				CARotateInterval:   OneYearDuration,
+				CAOverlapInterval:  OneYearDuration,
+				CertRotateInterval: OneYearDuration,
+			},
+			isValid: true,
+		}),
+		Entry("Passing WebhookType MutatingWebhook options should be valid", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:   "MyNamespace",
+				WebhookName: "MyWebhook",
+				WebhookType: MutatingWebhook,
+			},
+			expectedOptions: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				WebhookType:        MutatingWebhook,
+				CARotateInterval:   OneYearDuration,
+				CAOverlapInterval:  OneYearDuration,
+				CertRotateInterval: OneYearDuration,
+			},
+			isValid: true,
+		}),
+		Entry("Passing unknown WebhookType should be invalid", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:   "MyNamespace",
+				WebhookName: "MyWebhook",
+				WebhookType: "BadWebhookType",
+			},
+			expectedOptions: Options{
+				Namespace:   "MyNamespace",
+				WebhookName: "MyWebhook",
+				WebhookType: "BadWebhookType",
+			},
+			isValid: false,
+		}),
+		Entry("CAOverlapInterval has to default to CARotateInterval", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:        "MyNamespace",
+				WebhookName:      "MyWebhook",
+				CARotateInterval: 2 * OneYearDuration,
+			},
+			expectedOptions: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				WebhookType:        MutatingWebhook,
+				CARotateInterval:   2 * OneYearDuration,
+				CAOverlapInterval:  2 * OneYearDuration,
+				CertRotateInterval: 2 * OneYearDuration,
+			},
+			isValid: true,
+		}),
+		Entry("CertRotateInterval has to default to CARotateInterval", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:         "MyNamespace",
+				WebhookName:       "MyWebhook",
+				CARotateInterval:  2 * OneYearDuration,
+				CAOverlapInterval: 1 * OneYearDuration,
+			},
+			expectedOptions: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				WebhookType:        MutatingWebhook,
+				CARotateInterval:   2 * OneYearDuration,
+				CAOverlapInterval:  1 * OneYearDuration,
+				CertRotateInterval: 2 * OneYearDuration,
+			},
+			isValid: true,
+		}),
+		Entry("Passing CAOverlapInterval > CARotateInterval should be invalid", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:         "MyNamespace",
+				WebhookName:       "MyWebhook",
+				CARotateInterval:  1 * time.Hour,
+				CAOverlapInterval: 2 * time.Hour,
+			},
+			expectedOptions: Options{
+				Namespace:         "MyNamespace",
+				WebhookName:       "MyWebhook",
+				CARotateInterval:  1 * time.Hour,
+				CAOverlapInterval: 2 * time.Hour,
+			},
+			isValid: false,
+		}),
+		Entry("Passing CertRotateInterval > CARotateInterval should be invalid", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				CARotateInterval:   1 * time.Hour,
+				CertRotateInterval: 2 * time.Hour,
+			},
+			expectedOptions: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				CARotateInterval:   1 * time.Hour,
+				CertRotateInterval: 2 * time.Hour,
+			},
+			isValid: false,
+		}),
+		Entry("Passing all options override defaults", setDefaultsAndValidateCase{
+			options: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				WebhookType:        ValidatingWebhook,
+				CARotateInterval:   1 * time.Hour,
+				CAOverlapInterval:  1 * time.Minute,
+				CertRotateInterval: 30 * time.Minute,
+			},
+			expectedOptions: Options{
+				Namespace:          "MyNamespace",
+				WebhookName:        "MyWebhook",
+				WebhookType:        ValidatingWebhook,
+				CARotateInterval:   1 * time.Hour,
+				CAOverlapInterval:  1 * time.Minute,
+				CertRotateInterval: 30 * time.Minute,
+			},
+			isValid: true,
+		}),
+	)
+})

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -33,18 +33,23 @@ type ServerModifier func(w *webhook.Server)
 
 // Add creates a new Conditions Mutating Webhook and adds it to the Manager. The Manager will set fields on the Webhook
 // and Start it when the Manager is Started.
-func New(client client.Client, certificateOpts certificate.Options, serverOpts ...ServerModifier) *Server {
+func New(client client.Client, certificateOpts certificate.Options, serverOpts ...ServerModifier) (*Server, error) {
+	certManager, err := certificate.NewManager(client, certificateOpts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed constructing certificate manager")
+	}
+
 	s := &Server{
 		webhookServer: &webhook.Server{
 			Port:    8443,
 			CertDir: "/etc/webhook/certs/",
 		},
-		certManager: certificate.NewManager(client, certificateOpts),
+		certManager: certManager,
 		log:         logf.Log.WithName("webhook/server"),
 	}
 	s.UpdateOpts(serverOpts...)
 	s.webhookServer.Register("/readyz", healthz.CheckHandler{Checker: healthz.Ping})
-	return s
+	return s, nil
 }
 
 func WithHook(path string, hook *webhook.Admission) ServerModifier {

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Webhook server", func() {
 				return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 			}
 
-			server := New(cli, certificate.Options{WebhookName: expectedMutatingWebhookConfiguration.Name, WebhookType: certificate.MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration},
+			server, err := New(cli, certificate.Options{WebhookName: expectedMutatingWebhookConfiguration.Name, WebhookType: certificate.MutatingWebhook, Namespace: expectedNamespace.Name, CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration},
 				WithCertDir(certDir),
 				WithPort(freePort),
 				WithHook("/mutatepod",
@@ -92,6 +92,8 @@ var _ = Describe("Webhook server", func() {
 						Handler: admission.HandlerFunc(mutatedPodHandler),
 					}),
 			)
+
+			Expect(err).To(Succeed(), "should succceed constructing webhook server")
 
 			err = server.Add(mgr)
 			Expect(err).To(Succeed(), "should succeed adding the webhook server to the manager")

--- a/test/pod/main.go
+++ b/test/pod/main.go
@@ -75,8 +75,15 @@ func main() {
 
 	// Setup webhooks
 	entryLog.Info("setting up webhook server")
-	mutatingWebhookServer := webhookserver.New(mgr.GetClient(), certificate.Options{WebhookName: "test-webhook", WebhookType: certificate.MutatingWebhook, Namespace: "mynamespace", CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration})
-	validatingWebhookServer := webhookserver.New(mgr.GetClient(), certificate.Options{WebhookName: "test-webhook", WebhookType: certificate.ValidatingWebhook, Namespace: "mynamespace", CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration})
+	mutatingWebhookServer, err := webhookserver.New(mgr.GetClient(), certificate.Options{WebhookName: "test-webhook", WebhookType: certificate.MutatingWebhook, Namespace: "mynamespace", CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration})
+	if err != nil {
+		os.Exit(1)
+	}
+
+	validatingWebhookServer, err := webhookserver.New(mgr.GetClient(), certificate.Options{WebhookName: "test-webhook", WebhookType: certificate.ValidatingWebhook, Namespace: "mynamespace", CARotateInterval: certificate.OneYearDuration, CertRotateInterval: certificate.OneYearDuration})
+	if err != nil {
+		os.Exit(1)
+	}
 
 	entryLog.Info("registering webhooks to the webhook server")
 	mutatingWebhookServer.UpdateOpts(webhookserver.WithHook("/mutate-v1-pod", &webhook.Admission{Handler: &podAnnotator{Client: mgr.GetClient()}}))


### PR DESCRIPTION
This commit add a knob to configure how much time time a CA certificate that is not
the latest generated on after rotation can live at
CABunlde instead of using expiration time, if it's not set it uses CARotateInterval
which is similar to expiration time. This reduce the size of CABundle.