### PR TITLE
Bump to go 1.15 to get SubjectKeyId at CA certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test: $(GO) testenv
 pod:
 	$(GO) build -o $(BIN_DIR) ./pkg/... ./test/pod
 
-vendor:
+vendor: $(GO)
 	$(GO) mod tidy
 	$(GO) mod vendor
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qinqon/kube-admission-webhook
 
-go 1.13
+go 1.15
 
 require (
 	github.com/github-release/github-release v0.8.1

--- a/pkg/certificate/triple/triple_suite_test.go
+++ b/pkg/certificate/triple/triple_suite_test.go
@@ -1,0 +1,15 @@
+package triple
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+)
+
+func TestTriple(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.triple_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Certificate Test Suite", []Reporter{junitReporter})
+}

--- a/pkg/certificate/triple/triple_test.go
+++ b/pkg/certificate/triple/triple_test.go
@@ -1,0 +1,45 @@
+package triple
+
+import (
+	"crypto/x509"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cert library", func() {
+	Context("when NewCA is called", func() {
+		var (
+			name     string
+			duration time.Duration
+			now      time.Time
+		)
+		BeforeEach(func() {
+			now = time.Now()
+			name = "foo-bar-name"
+			duration = time.Minute
+			Now = func() time.Time { return now }
+		})
+		It("should generate key and CA cert with expected fields", func() {
+
+			keyAndCert, err := NewCA(name, duration)
+			Expect(err).ToNot(HaveOccurred(), "should succeed generating CA")
+
+			privateKey := keyAndCert.Key
+			caCert := keyAndCert.Cert
+
+			Expect(privateKey).ToNot(BeNil(), "should generate a private key")
+			Expect(caCert).ToNot(BeNil(), "should generate a CA certificate")
+			Expect(caCert.SerialNumber.Int64()).To(Equal(int64(0)), "should have zero as serial number")
+			Expect(caCert.Subject.CommonName).To(Equal(name), "should take CommonName from name field")
+			Expect(caCert.NotBefore).To(BeTemporally("~", now.UTC(), time.Second), "should set NotBefore to now")
+			Expect(caCert.NotAfter).To(BeTemporally("~", now.Add(duration).UTC(), time.Second), "should  set NotAfter to now + duration")
+			Expect(caCert.KeyUsage).To(Equal(x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign), "should set proper KeyUsage")
+			Expect(caCert.BasicConstraintsValid).To(BeTrue(), "should mark it as BasicConstraintsValid")
+			Expect(caCert.IsCA).To(BeTrue(), "should mark it as CA")
+			Expect(caCert.SubjectKeyId).ToNot(BeEmpty(), "should include a SKI")
+		})
+
+	})
+})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,9 +9,11 @@ github.com/dustin/go-humanize
 # github.com/evanphx/json-patch v4.5.0+incompatible
 github.com/evanphx/json-patch
 # github.com/github-release/github-release v0.8.1
+## explicit
 github.com/github-release/github-release
 github.com/github-release/github-release/github
 # github.com/go-logr/logr v0.1.0
+## explicit
 github.com/go-logr/logr
 # github.com/go-logr/zapr v0.1.0
 github.com/go-logr/zapr
@@ -54,12 +56,15 @@ github.com/hpcloud/tail/winfile
 # github.com/imdario/mergo v0.3.6
 github.com/imdario/mergo
 # github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1
+## explicit
 github.com/inconshreveable/log15
 # github.com/json-iterator/go v1.1.8
 github.com/json-iterator/go
 # github.com/kevinburke/rest v0.0.0-20200429221318-0d2892b400f8
+## explicit
 github.com/kevinburke/rest
 # github.com/mattn/go-colorable v0.1.6
+## explicit
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.12
 github.com/mattn/go-isatty
@@ -70,6 +75,7 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
 # github.com/onsi/ginkgo v1.11.0
+## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/extensions/table
@@ -90,6 +96,7 @@ github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
 # github.com/onsi/gomega v1.8.1
+## explicit
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gbytes
@@ -105,8 +112,10 @@ github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
+## explicit
 github.com/phayes/freeport
 # github.com/pkg/errors v0.8.1
+## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.0.0
 github.com/prometheus/client_golang/prometheus
@@ -124,8 +133,10 @@ github.com/prometheus/procfs/internal/fs
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
+## explicit
 github.com/tomnomnom/linkheader
 # github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2
+## explicit
 github.com/voxelbrain/goptions
 # go.uber.org/atomic v1.4.0
 go.uber.org/atomic
@@ -207,6 +218,7 @@ gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
 # k8s.io/api v0.18.2 => k8s.io/api v0.18.2
+## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -257,6 +269,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 # k8s.io/apimachinery v0.18.2 => k8s.io/apimachinery v0.18.2
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -302,6 +315,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v0.18.2 => k8s.io/client-go v0.18.2
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/dynamic
 k8s.io/client-go/kubernetes
@@ -379,6 +393,7 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 k8s.io/kube-openapi/pkg/util/proto
@@ -388,6 +403,7 @@ k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.6.0
+## explicit
 sigs.k8s.io/controller-runtime/pkg/cache
 sigs.k8s.io/controller-runtime/pkg/cache/internal
 sigs.k8s.io/controller-runtime/pkg/client
@@ -428,3 +444,23 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# k8s.io/api => k8s.io/api v0.18.2
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.2
+# k8s.io/apimachinery => k8s.io/apimachinery v0.18.2
+# k8s.io/apiserver => k8s.io/apiserver v0.18.2
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.2
+# k8s.io/client-go => k8s.io/client-go v0.18.2
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.2
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.2
+# k8s.io/component-base => k8s.io/component-base v0.18.2
+# k8s.io/cri-api => k8s.io/cri-api v0.18.2
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.2
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.2
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.2
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.2
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.2
+# k8s.io/kubelet => k8s.io/kubelet v0.18.2
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.2
+# k8s.io/metrics => k8s.io/metrics v0.18.2
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.2
+# kubevirt.io/client-go => github.com/kubevirt/client-go v0.29.0


### PR DESCRIPTION
Go crypto library for versions < 1.15 is not filling in the SKI field for CAs [1] so we bump to 1.15
[1] golang/go#26676
[2] https://go-review.googlesource.com/c/go/+/227098/

Closes: #42 