### PR TITLE
Prepend certs instead of append

### DIFF
--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -120,7 +120,7 @@ func (m *Manager) getCACertsFromCABundle() ([]*x509.Certificate, error) {
 	return cas, nil
 }
 
-func (m *Manager) getLastAppendedCACertFromCABundle() (*x509.Certificate, error) {
+func (m *Manager) getLastPrependedCACertFromCABundle() (*x509.Certificate, error) {
 	cas, err := m.getCACertsFromCABundle()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed getting CA certificates from CA bundle")
@@ -128,7 +128,7 @@ func (m *Manager) getLastAppendedCACertFromCABundle() (*x509.Certificate, error)
 	if len(cas) == 0 {
 		return nil, nil
 	}
-	return cas[len(cas)-1], nil
+	return cas[0], nil
 }
 
 func (m *Manager) rotateAll() error {
@@ -262,7 +262,7 @@ func (m *Manager) nextRotationDeadlineForCA() time.Time {
 
 	// Last rotated CA cert at CABundle is the last at the slice so this
 	// calculate deadline from it.
-	caCert, err := m.getLastAppendedCACertFromCABundle()
+	caCert, err := m.getLastPrependedCACertFromCABundle()
 	if err != nil {
 		m.log.Info("Failed reading last CA cert from CABundle, forcing rotation", "err", err)
 		return m.now()

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -254,7 +254,7 @@ var _ = Describe("certificate manager", func() {
 
 				obtainedMutatingWebhookConfiguration := loadMutatingWebhook(m)
 				caBundle := obtainedMutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle
-				hackedCABundle := append(caBundle, triple.EncodeCertPEM(hackedCA.Cert)...)
+				hackedCABundle := append(triple.EncodeCertPEM(hackedCA.Cert), caBundle...)
 				obtainedMutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle = hackedCABundle
 				updateMutatingWebhook(m, &obtainedMutatingWebhookConfiguration)
 			},

--- a/pkg/certificate/secret.go
+++ b/pkg/certificate/secret.go
@@ -166,7 +166,7 @@ func (m *Manager) verifyTLSSecret(secretKey types.NamespacedName, caKeyPair *tri
 		return errors.New("CA bundle has no certificates")
 	}
 
-	lastCertFromCABundle := getLastCert(certsFromCABundle)
+	lastCertFromCABundle := getFirstCert(certsFromCABundle)
 
 	if !reflect.DeepEqual(*lastCertFromCABundle, *caKeyPair.Cert) {
 		return errors.New("CA bundle and CA secret certificate are different")
@@ -236,9 +236,9 @@ func (m *Manager) getTLSKeyPair(secretKey types.NamespacedName) (*triple.KeyPair
 		return nil, errors.Wrapf(err, "failed parsing TLS private key PEM at secret %s", secretKey)
 	}
 
-	lastAppendedCert := getLastCert(certs)
+	lastPrependedCert := getFirstCert(certs)
 
-	return &triple.KeyPair{Key: privateKey.(*rsa.PrivateKey), Cert: lastAppendedCert}, nil
+	return &triple.KeyPair{Key: privateKey.(*rsa.PrivateKey), Cert: lastPrependedCert}, nil
 }
 
 func (m *Manager) getTLSCerts(secretKey types.NamespacedName) ([]*x509.Certificate, error) {
@@ -265,11 +265,11 @@ func (m *Manager) caSecretKey() types.NamespacedName {
 	return types.NamespacedName{Namespace: m.namespace, Name: m.webhookName + "-ca"}
 }
 
-// Certs are appended to implement overlap so we take the last one
+// Certs are prepended to implement overlap so we take the first one
 // it will match with the key
-func getLastCert(certs []*x509.Certificate) *x509.Certificate {
+func getFirstCert(certs []*x509.Certificate) *x509.Certificate {
 	if len(certs) == 0 {
 		return nil
 	}
-	return certs[len(certs)-1]
+	return certs[0]
 }

--- a/pkg/certificate/triple/cert.go
+++ b/pkg/certificate/triple/cert.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -175,6 +176,11 @@ func VerifyTLS(certsPEM, keyPEM, caBundle []byte) error {
 
 	if _, err := certs[0].Verify(opts); err != nil {
 		return errors.Wrap(err, "failed to verify certificate")
+	}
+
+	_, err = tls.X509KeyPair(certsPEM, keyPEM)
+	if err != nil {
+		return errors.Wrap(err, "failed parsing TLS public/private key")
 	}
 
 	logger.Info("TLS certificates chain verified")

--- a/pkg/certificate/triple/pem.go
+++ b/pkg/certificate/triple/pem.go
@@ -197,7 +197,9 @@ func AddCertToPEM(cert *x509.Certificate, pemCerts []byte) ([]byte, error) {
 			return nil, fmt.Errorf("failed parsing current certs PEM: %w", err)
 		}
 	}
-	certs = append(certs, cert)
+	// Prepend cert since it's what TLS expects [1]
+	// [1] https://github.com/golang/go/blob/master/src/crypto/tls/tls.go#L292-L294
+	certs = append([]*x509.Certificate{cert}, certs...)
 	return EncodeCertsPEM(certs), nil
 }
 


### PR DESCRIPTION
To implement cert overlap multiple pub keys has to life at the cert
bundle currectly this is implemented appending new certs but this is not
ok from TLS perspective since the first public key or "leaf" has to
match with the private key [1].

[1] https://github.com/golang/go/blob/master/src/crypto/tls/tls.go#L292-L294

Test PR on kubernetes-nmstate https://github.com/nmstate/kubernetes-nmstate/pull/734
Test PR on kubemacpool https://github.com/k8snetworkplumbingwg/kubemacpool/pull/289

Signed-off-by: Quique Llorente <ellorent@redhat.com>