### PR TITLE
Remove obsolete certs and keys

### DIFF
--- a/pkg/certificate/configuration.go
+++ b/pkg/certificate/configuration.go
@@ -91,6 +91,17 @@ func (m *Manager) addCertificateToCABundle(caCert *x509.Certificate) error {
 	return nil
 }
 
+func (m *Manager) resetWebhookCABundle() error {
+	m.log.Info("Reset CA bundle with empty value")
+	_, err := m.updateWebhookCABundleWithFunc(func([]byte) ([]byte, error) {
+		return []byte{}, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to update webhook CABundle")
+	}
+	return nil
+}
+
 func (m *Manager) updateWebhookCABundleWithFunc(updateCABundle func([]byte) ([]byte, error)) (client.Object, error) {
 	m.log.Info("Updating CA bundle for webhook")
 	var webhook client.Object

--- a/pkg/certificate/controller.go
+++ b/pkg/certificate/controller.go
@@ -89,6 +89,11 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (rec
 	reqLogger := m.log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name).WithName("Reconcile")
 	reqLogger.Info("Reconciling Certificates")
 
+	err := m.removeObsoleteCertificateBundles()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	elapsedToRotateCA := m.elapsedToRotateCAFromLastDeadline()
 	elapsedToRotateServices := m.elapsedToRotateServicesFromLastDeadline()
 


### PR DESCRIPTION
Priori v0.15.0 the cert overlap was implemented adding appending new
certs but this is not correct [1], latest version of the
kube-admission-webhook lib do a prepend to comply with TLS verification
at golang web server, this introduce a problem at upgrades since it will
take into account the cert at the end but it will not point to the last
one.

[1] https://github.com/qinqon/kube-admission-webhook/pull/48

Signed-off-by: Quique Llorente <ellorent@redhat.com>