### PR TITLE
Relationship labels, Label self deployed resources

### DIFF
--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -59,6 +59,9 @@ type Manager struct {
 	// log initialized log that containes the webhook configuration name and
 	// namespace so it's easy to debug.
 	log logr.Logger
+
+	// extraLabels Options.ExtraLabels
+	extraLabels map[string]string
 }
 
 // NewManager with create a certManager that generated a secret per service
@@ -97,6 +100,7 @@ func NewManager(
 		caOverlapDuration:      options.CAOverlapInterval,
 		serviceCertDuration:    options.CertRotateInterval,
 		serviceOverlapDuration: options.CertOverlapInterval,
+		extraLabels:            options.ExtraLabels,
 		log: logf.Log.WithName("certificate/Manager").
 			WithValues("webhookType", options.WebhookType, "webhookName", options.WebhookName),
 	}

--- a/pkg/certificate/options.go
+++ b/pkg/certificate/options.go
@@ -40,6 +40,9 @@ type Options struct {
 	// CertOverlapInterval the duration of service certificates at bundle if
 	// not set it will default to CertRotateInterval
 	CertOverlapInterval time.Duration
+
+	// ExtraLabels extra labels that will be added to created secrets
+	ExtraLabels map[string]string
 }
 
 func (o *Options) validate() error {

--- a/pkg/certificate/secret.go
+++ b/pkg/certificate/secret.go
@@ -110,6 +110,7 @@ func (m *Manager) applySecret(secretKey types.NamespacedName, secretType corev1.
 						Name:        secretKey.Name,
 						Namespace:   secretKey.Namespace,
 						Annotations: map[string]string{},
+						Labels:      m.extraLabels,
 					},
 					Type: secretType,
 				}


### PR DESCRIPTION
In order to have relationship labels (app.kubernetes.io/*)
on all managed resources,
this commit adds an `ExtraLabels` field to the Manager options.
This way, the created secrets will be labeled.

The labels are inherited from the cert manager pod.
The pod will have those labels if deployed by OLM / HCO,
otherwise it won't and the labels won't be added to the above
resources.

It is the user responsibility to add the extra labels
to the options.

Signed-off-by: Or Shoval <oshoval@redhat.com>