### PR TITLE
[release-0.12] certs, Add Certs list size limit

### DIFF
--- a/pkg/certificate/configuration.go
+++ b/pkg/certificate/configuration.go
@@ -92,6 +92,7 @@ func (m *Manager) addCertificateToCABundle(caCert *x509.Certificate) error {
 			}
 		}
 		cas = append(cas, caCert)
+		cas = triple.RemoveOldestCerts(cas, triple.CertsListSizeLimit)
 		return triple.EncodeCertsPEM(cas), nil
 	})
 	if err != nil {

--- a/pkg/certificate/triple/pem.go
+++ b/pkg/certificate/triple/pem.go
@@ -38,6 +38,8 @@ const (
 	CertificateBlockType = "CERTIFICATE"
 	// CertificateRequestBlockType is a possible value for pem.Block.Type.
 	CertificateRequestBlockType = "CERTIFICATE REQUEST"
+	// CertsListSizeLimit sets the max size of a certs list
+	CertsListSizeLimit = 100
 )
 
 // EncodePublicKeyPEM returns PEM-encoded public data
@@ -79,6 +81,15 @@ func EncodeCertsPEM(certs []*x509.Certificate) []byte {
 		certsPEM = append(certsPEM, certPEM...)
 	}
 	return certsPEM
+}
+
+// RemoveOldestCerts removes old certs to avoid bloating
+func RemoveOldestCerts(certs []*x509.Certificate, maxListSize int) []*x509.Certificate {
+	if len(certs) <= maxListSize {
+		return certs
+	}
+	// oldest certs are in the start
+	return certs[len(certs)-maxListSize:]
 }
 
 // ParsePrivateKeyPEM returns a private key parsed from a PEM block in the supplied data.

--- a/pkg/certificate/triple/triple_suite_test.go
+++ b/pkg/certificate/triple/triple_suite_test.go
@@ -1,0 +1,15 @@
+package triple
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+)
+
+func TestTriple(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.triple_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Certificate Test Suite", []Reporter{junitReporter})
+}

--- a/pkg/certificate/triple/triple_test.go
+++ b/pkg/certificate/triple/triple_test.go
@@ -1,0 +1,55 @@
+package triple
+
+import (
+	"crypto/x509"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cert library", func() {
+
+	type removeOldestCertsParams struct {
+		certsList         []*x509.Certificate
+		maxListSize       int
+		expectedCertsList []*x509.Certificate
+	}
+	certOldest := &x509.Certificate{
+		NotBefore: time.Now().Add(10*time.Hour),
+		NotAfter:  time.Now(),
+	}
+	certOld := &x509.Certificate{
+		NotBefore: time.Now().Add(5*time.Hour),
+		NotAfter:  time.Now(),
+	}
+	certCurrent := &x509.Certificate{
+		NotBefore: time.Now(),
+		NotAfter:  time.Now(),
+	}
+
+	DescribeTable("removeOldestCerts",
+		func(c removeOldestCertsParams) {
+			Expect(RemoveOldestCerts(c.certsList, c.maxListSize)).To(ConsistOf(c.expectedCertsList), "should remove the oldest certs")
+		},
+		Entry("when list is empty",
+			removeOldestCertsParams{
+				certsList:         []*x509.Certificate{},
+				maxListSize:       2,
+				expectedCertsList: []*x509.Certificate{},
+			}),
+		Entry("when list size is less or equal to max certs, should keep the certs list intact",
+			removeOldestCertsParams{
+				certsList:         []*x509.Certificate{certOldest, certOld, certCurrent},
+				maxListSize:        3,
+				expectedCertsList: []*x509.Certificate{certOldest, certOld, certCurrent},
+			}),
+		Entry("when list size is bigger than max certs, should remove the oldest certs",
+			removeOldestCertsParams{
+				certsList:         []*x509.Certificate{certOldest, certOld, certCurrent},
+				maxListSize:       2,
+				expectedCertsList: []*x509.Certificate{certOld, certCurrent},
+			}),
+	)
+})


### PR DESCRIPTION
certs, Add Certs list size limit
Currently certs are appended without limit. This can
cause a problem when applying the caBundle/certs on the
mutatingwebhookconfiguration/secret, appropriately - due
to etcd's POST size limit.
Limited the amount of certs to 100.

Signed-off-by: Ram Lavi <ralavi@redhat.com>