### PR TITLE
webhook: Implement controller-runtime webhook server with CipherSuites knob

### DIFF
--- a/pkg/webhook/internal/httpserver/server.go
+++ b/pkg/webhook/internal/httpserver/server.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Kube Admission Webhook Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"net/http"
+	"time"
+)
+
+// New returns a new server with sane defaults.
+func New(handler http.Handler) *http.Server {
+	return &http.Server{
+		Handler:           handler,
+		MaxHeaderBytes:    1 << 20,
+		IdleTimeout:       90 * time.Second, // matches http.DefaultTransport keep-alive timeout
+		ReadHeaderTimeout: 32 * time.Second,
+	}
+}

--- a/pkg/webhook/internal/metrics/metrics.go
+++ b/pkg/webhook/internal/metrics/metrics.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Kube Admission Webhook Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// RequestLatency is a prometheus metric which is a histogram of the latency
+	// of processing admission requests.
+	RequestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "kaw_latency_seconds",
+			Help: "Histogram of the latency of processing admission requests",
+		},
+		[]string{"webhook"},
+	)
+
+	// RequestTotal is a prometheus metric which is a counter of the total processed admission requests.
+	RequestTotal = func() *prometheus.CounterVec {
+		return prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "kaw_requests_total",
+				Help: "Total number of admission requests by HTTP status code.",
+			},
+			[]string{"webhook", "code"},
+		)
+	}()
+
+	// RequestInFlight is a prometheus metric which is a gauge of the in-flight admission requests.
+	RequestInFlight = func() *prometheus.GaugeVec {
+		return prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "kaw_requests_in_flight",
+				Help: "Current number of admission requests being served.",
+			},
+			[]string{"webhook"},
+		)
+	}()
+)
+
+func init() {
+	metrics.Registry.MustRegister(RequestLatency, RequestTotal, RequestInFlight)
+}
+
+// InstrumentedHook adds some instrumentation on top of the given webhook.
+func InstrumentedHook(path string, hookRaw http.Handler) http.Handler {
+	lbl := prometheus.Labels{"webhook": path}
+
+	lat := RequestLatency.MustCurryWith(lbl)
+	cnt := RequestTotal.MustCurryWith(lbl)
+	gge := RequestInFlight.With(lbl)
+
+	// Initialize the most likely HTTP status codes.
+	cnt.WithLabelValues("200")
+	cnt.WithLabelValues("500")
+
+	return promhttp.InstrumentHandlerDuration(
+		lat,
+		promhttp.InstrumentHandlerCounter(
+			cnt,
+			promhttp.InstrumentHandlerInFlight(gge, hookRaw),
+		),
+	)
+}

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2022 The Kube Admission Webhook Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+
+	"github.com/qinqon/kube-admission-webhook/pkg/webhook/internal/httpserver"
+	"github.com/qinqon/kube-admission-webhook/pkg/webhook/internal/metrics"
+)
+
+var log = logf.Log.WithName("PoolManager")
+
+// DefaultPort is the default port that the webhook server serves.
+var DefaultPort = 9443
+
+// Server is an admission webhook server that can serve traffic and
+// generates related k8s resources for deploying.
+//
+// TLS is required for a webhook to be accessed by kubernetes, so
+// you must provide a CertName and KeyName or have valid cert/key
+// at the default locations (tls.crt and tls.key). If you do not
+// want to configure TLS (i.e for testing purposes) run an
+// admission.StandaloneWebhook in your own server.
+//
+// NOTE: This has being copied from https://github.com/kubernetes-sigs/controller-runtime/blob/v0.11.1/pkg/webhook/server.go
+type Server struct {
+	// Host is the address that the server will listen on.
+	// Defaults to "" - all addresses.
+	Host string
+
+	// Port is the port number that the server will serve.
+	// It will be defaulted to 9443 if unspecified.
+	Port int
+
+	// CertDir is the directory that contains the server key and certificate. The
+	// server key and certificate.
+	CertDir string
+
+	// CertName is the server certificate name. Defaults to tls.crt.
+	CertName string
+
+	// KeyName is the server key name. Defaults to tls.key.
+	KeyName string
+
+	// ClientCAName is the CA certificate name which server used to verify remote(client)'s certificate.
+	// Defaults to "", which means server does not verify client's certificate.
+	ClientCAName string
+
+	// TLSVersion is the minimum version of TLS supported. Accepts
+	// "", "1.0", "1.1", "1.2" and "1.3" only ("" is equivalent to "1.0" for backwards compatibility)
+	TLSMinVersion string
+
+	// WebhookMux is the multiplexer that handles different webhooks.
+	WebhookMux *http.ServeMux
+
+	// webhooks keep track of all registered webhooks for dependency injection,
+	// and to provide better panic messages on duplicate webhook registration.
+	webhooks map[string]http.Handler
+
+	// setFields allows injecting dependencies from an external source
+	setFields inject.Func
+
+	// defaultingOnce ensures that the default fields are only ever set once.
+	defaultingOnce sync.Once
+
+	// started is set to true immediately before the server is started
+	// and thus can be used to check if the server has been started
+	started bool
+
+	// mu protects access to the webhook map & setFields for Start, Register, etc
+	mu sync.Mutex
+}
+
+// setDefaults does defaulting for the Server.
+func (s *Server) setDefaults() {
+	s.webhooks = map[string]http.Handler{}
+	if s.WebhookMux == nil {
+		s.WebhookMux = http.NewServeMux()
+	}
+
+	if s.Port <= 0 {
+		s.Port = DefaultPort
+	}
+
+	if len(s.CertDir) == 0 {
+		s.CertDir = filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs")
+	}
+
+	if len(s.CertName) == 0 {
+		s.CertName = "tls.crt"
+	}
+
+	if len(s.KeyName) == 0 {
+		s.KeyName = "tls.key"
+	}
+}
+
+// NeedLeaderElection implements the LeaderElectionRunnable interface, which indicates
+// the webhook server doesn't need leader election.
+func (*Server) NeedLeaderElection() bool {
+	return false
+}
+
+// Register marks the given webhook as being served at the given path.
+// It panics if two hooks are registered on the same path.
+func (s *Server) Register(path string, hook http.Handler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.defaultingOnce.Do(s.setDefaults)
+	if _, found := s.webhooks[path]; found {
+		panic(fmt.Errorf("can't register duplicate path: %v", path))
+	}
+	// TODO(directxman12): call setfields if we've already started the server
+	s.webhooks[path] = hook
+	s.WebhookMux.Handle(path, metrics.InstrumentedHook(path, hook))
+
+	regLog := log.WithValues("path", path)
+	regLog.Info("Registering webhook")
+
+	// we've already been "started", inject dependencies here.
+	// Otherwise, InjectFunc will do this for us later.
+	if s.setFields != nil {
+		if err := s.setFields(hook); err != nil {
+			// TODO(directxman12): swallowing this error isn't great, but we'd have to
+			// change the signature to fix that
+			regLog.Error(err, "unable to inject fields into webhook during registration")
+		}
+
+		baseHookLog := log.WithName("webhooks")
+
+		// NB(directxman12): we don't propagate this further by wrapping setFields because it's
+		// unclear if this is how we want to deal with log propagation.  In this specific instance,
+		// we want to be able to pass a logger to webhooks because they don't know their own path.
+		if _, err := inject.LoggerInto(baseHookLog.WithValues("webhook", path), hook); err != nil {
+			regLog.Error(err, "unable to logger into webhook during registration")
+		}
+	}
+}
+
+// StartStandalone runs a webhook server without
+// a controller manager.
+func (s *Server) StartStandalone(ctx context.Context, scheme *runtime.Scheme) error {
+	// Use the Kubernetes client-go scheme if none is specified
+	if scheme == nil {
+		scheme = kscheme.Scheme
+	}
+
+	if err := s.InjectFunc(func(i interface{}) error {
+		if _, err := inject.SchemeInto(scheme, i); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return s.Start(ctx)
+}
+
+// tlsVersion converts from human-readable TLS version (for example "1.1")
+// to the values accepted by tls.Config (for example 0x301).
+func tlsVersion(version string) (uint16, error) {
+	switch version {
+	// default is previous behaviour
+	case "":
+		return tls.VersionTLS10, nil
+	case "1.0":
+		return tls.VersionTLS10, nil
+	case "1.1":
+		return tls.VersionTLS11, nil
+	case "1.2":
+		return tls.VersionTLS12, nil
+	case "1.3":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("invalid TLSMinVersion %v: expects 1.0, 1.1, 1.2, 1.3 or empty", version)
+	}
+}
+
+// Start runs the server.
+// It will install the webhook related resources depend on the server configuration.
+func (s *Server) Start(ctx context.Context) error {
+	s.defaultingOnce.Do(s.setDefaults)
+
+	baseHookLog := log.WithName("webhooks")
+	baseHookLog.Info("Starting webhook server")
+
+	certPath := filepath.Join(s.CertDir, s.CertName)
+	keyPath := filepath.Join(s.CertDir, s.KeyName)
+
+	certWatcher, err := certwatcher.New(certPath, keyPath)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		if err := certWatcher.Start(ctx); err != nil {
+			log.Error(err, "certificate watcher error")
+		}
+	}()
+
+	tlsMinVersion, err := tlsVersion(s.TLSMinVersion)
+	if err != nil {
+		return err
+	}
+
+	cfg := &tls.Config{ //nolint:gosec
+		NextProtos:     []string{"h2"},
+		GetCertificate: certWatcher.GetCertificate,
+		MinVersion:     tlsMinVersion,
+	}
+
+	// load CA to verify client certificate
+	if s.ClientCAName != "" {
+		certPool := x509.NewCertPool()
+		clientCABytes, err := ioutil.ReadFile(filepath.Join(s.CertDir, s.ClientCAName))
+		if err != nil {
+			return fmt.Errorf("failed to read client CA cert: %v", err)
+		}
+
+		ok := certPool.AppendCertsFromPEM(clientCABytes)
+		if !ok {
+			return fmt.Errorf("failed to append client CA cert to CA pool")
+		}
+
+		cfg.ClientCAs = certPool
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	listener, err := tls.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)), cfg)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Serving webhook server", "host", s.Host, "port", s.Port)
+
+	srv := httpserver.New(s.WebhookMux)
+
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		log.Info("shutting down webhook server")
+
+		// TODO: use a context with reasonable timeout
+		if err := srv.Shutdown(context.Background()); err != nil {
+			// Error from closing listeners, or context timeout
+			log.Error(err, "error shutting down the HTTP server")
+		}
+		close(idleConnsClosed)
+	}()
+
+	s.mu.Lock()
+	s.started = true
+	s.mu.Unlock()
+	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+
+	<-idleConnsClosed
+	return nil
+}
+
+// StartedChecker returns an healthz.Checker which is healthy after the
+// server has been started.
+func (s *Server) StartedChecker() healthz.Checker {
+	config := &tls.Config{
+		InsecureSkipVerify: true, // nolint:gosec // config is used to connect to our own webhook port.
+	}
+	return func(req *http.Request) error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		if !s.started {
+			return fmt.Errorf("webhook server has not been started yet")
+		}
+
+		d := &net.Dialer{Timeout: 10 * time.Second}
+		conn, err := tls.DialWithDialer(d, "tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)), config)
+		if err != nil {
+			return fmt.Errorf("webhook server is not reachable: %v", err)
+		}
+
+		if err := conn.Close(); err != nil {
+			return fmt.Errorf("webhook server is not reachable: closing connection: %v", err)
+		}
+
+		return nil
+	}
+}
+
+// InjectFunc injects the field setter into the server.
+func (s *Server) InjectFunc(f inject.Func) error {
+	s.setFields = f
+
+	// inject fields here that weren't injected in Register because we didn't have setFields yet.
+	baseHookLog := log.WithName("webhooks")
+	for hookPath, webhook := range s.webhooks {
+		if err := s.setFields(webhook); err != nil {
+			return err
+		}
+
+		// NB(directxman12): we don't propagate this further by wrapping setFields because it's
+		// unclear if this is how we want to deal with log propagation.  In this specific instance,
+		// we want to be able to pass a logger to webhooks because they don't know their own path.
+		if _, err := inject.LoggerInto(baseHookLog.WithValues("webhook", hookPath), webhook); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2022 The Kube Admission Webhook Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/qinqon/kube-admission-webhook/pkg/webhook"
+)
+
+var _ = Describe("Webhook Server", func() {
+	var (
+		ctx          context.Context
+		ctxCancel    context.CancelFunc
+		testHostPort string
+		client       *http.Client
+		server       *webhook.Server
+		servingOpts  envtest.WebhookInstallOptions
+	)
+
+	BeforeEach(func() {
+		ctx, ctxCancel = context.WithCancel(context.Background())
+		// closed in individual tests differently
+
+		servingOpts = envtest.WebhookInstallOptions{}
+		Expect(servingOpts.PrepWithoutInstalling()).To(Succeed())
+
+		testHostPort = net.JoinHostPort(servingOpts.LocalServingHost, fmt.Sprintf("%d", servingOpts.LocalServingPort))
+
+		// bypass needing to set up the x509 cert pool, etc ourselves
+		clientTransport, err := rest.TransportFor(&rest.Config{
+			TLSClientConfig: rest.TLSClientConfig{CAData: servingOpts.LocalServingCAData},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		client = &http.Client{
+			Transport: clientTransport,
+		}
+
+		server = &webhook.Server{
+			Host:    servingOpts.LocalServingHost,
+			Port:    servingOpts.LocalServingPort,
+			CertDir: servingOpts.LocalServingCertDir,
+		}
+	})
+	AfterEach(func() {
+		Expect(servingOpts.Cleanup()).To(Succeed())
+	})
+
+	genericStartServer := func(f func(ctx context.Context)) (done <-chan struct{}) {
+		doneCh := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			defer close(doneCh)
+			f(ctx)
+		}()
+		// wait till we can ping the server to start the test
+		Eventually(func() error {
+			_, err := client.Get(fmt.Sprintf("https://%s/unservedpath", testHostPort))
+			return err
+		}).Should(Succeed())
+
+		// this is normally called before Start by the manager
+		Expect(server.InjectFunc(func(i interface{}) error {
+			boolInj, canInj := i.(interface{ InjectBool(bool) error })
+			if !canInj {
+				return nil
+			}
+			return boolInj.InjectBool(true)
+		})).To(Succeed())
+
+		return doneCh
+	}
+
+	startServer := func() (done <-chan struct{}) {
+		return genericStartServer(func(ctx context.Context) {
+			Expect(server.Start(ctx)).To(Succeed())
+		})
+	}
+
+	It("should panic if a duplicate path is registered", func() {
+		server.Register("/somepath", &testHandler{})
+		doneCh := startServer()
+
+		Expect(func() { server.Register("/somepath", &testHandler{}) }).To(Panic())
+
+		ctxCancel()
+		Eventually(doneCh, "4s").Should(BeClosed())
+	})
+
+	Context("when registering new webhooks before starting", func() {
+		It("should serve a webhook on the requested path", func() {
+			server.Register("/somepath", &testHandler{})
+
+			Expect(server.StartedChecker()(nil)).ToNot(Succeed())
+
+			doneCh := startServer()
+
+			Eventually(func() ([]byte, error) {
+				resp, err := client.Get(fmt.Sprintf("https://%s/somepath", testHostPort))
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				return ioutil.ReadAll(resp.Body)
+			}).Should(Equal([]byte("gadzooks!")))
+
+			Expect(server.StartedChecker()(nil)).To(Succeed())
+
+			ctxCancel()
+			Eventually(doneCh, "4s").Should(BeClosed())
+		})
+
+		It("should inject dependencies eventually, given an inject func is eventually provided", func() {
+			handler := &testHandler{}
+			server.Register("/somepath", handler)
+			doneCh := startServer()
+
+			Eventually(func() bool { return handler.injectedField }).Should(BeTrue())
+
+			ctxCancel()
+			Eventually(doneCh, "4s").Should(BeClosed())
+		})
+	})
+
+	Context("when registering webhooks after starting", func() {
+		var (
+			doneCh <-chan struct{}
+		)
+		BeforeEach(func() {
+			doneCh = startServer()
+		})
+		AfterEach(func() {
+			// wait for cleanup to happen
+			ctxCancel()
+			Eventually(doneCh, "4s").Should(BeClosed())
+		})
+
+		It("should serve a webhook on the requested path", func() {
+			server.Register("/somepath", &testHandler{})
+			resp, err := client.Get(fmt.Sprintf("https://%s/somepath", testHostPort))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(ioutil.ReadAll(resp.Body)).To(Equal([]byte("gadzooks!")))
+		})
+
+		It("should inject dependencies, if an inject func has been provided already", func() {
+			handler := &testHandler{}
+			server.Register("/somepath", handler)
+			Expect(handler.injectedField).To(BeTrue())
+		})
+	})
+
+	It("should serve be able to serve in unmanaged mode", func() {
+		server = &webhook.Server{
+			Host:    servingOpts.LocalServingHost,
+			Port:    servingOpts.LocalServingPort,
+			CertDir: servingOpts.LocalServingCertDir,
+		}
+		server.Register("/somepath", &testHandler{})
+		doneCh := genericStartServer(func(ctx context.Context) {
+			Expect(server.StartStandalone(ctx, scheme.Scheme))
+		})
+
+		Eventually(func() ([]byte, error) {
+			resp, err := client.Get(fmt.Sprintf("https://%s/somepath", testHostPort))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			return ioutil.ReadAll(resp.Body)
+		}).Should(Equal([]byte("gadzooks!")))
+
+		ctxCancel()
+		Eventually(doneCh, "4s").Should(BeClosed())
+	})
+})
+
+type testHandler struct {
+	injectedField bool
+}
+
+func (t *testHandler) InjectBool(val bool) error {
+	t.injectedField = val
+	return nil
+}
+func (t *testHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	if _, err := resp.Write([]byte("gadzooks!")); err != nil {
+		panic("unable to write http response!")
+	}
+}

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The Kube Admission Webhook Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWebhookServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
+}


### PR DESCRIPTION
The current controller-runtime allow to configure TLS min version but it
does not allow to configure the cipher suites. This change copy the
server from the controller-runtime library and add a CipherSuites knob to configure the TLS handshake cipher algorithms.

controller-runtime https server [does not expose](https://github.com/kubernetes-sigs/controller-runtime/issues/852#issuecomment-1062538456) the `tls.Config`, this PR has copied the server there to be able to modify tls.Config.
